### PR TITLE
feat: caching load methods

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+coverage/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+          "type": "node",
+          "request": "launch",
+          "name": "Jest All",
+          "program": "${workspaceFolder}/node_modules/.bin/jest",
+          "args": ["--runInBand"],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen",
+          "disableOptimisticBPs": true,
+          "windows": {
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+          }
+        },
+        {
+          "type": "node",
+          "request": "launch",
+          "name": "Jest Current File",
+          "program": "${workspaceFolder}/node_modules/.bin/jest",
+          "args": [
+            "${fileBasenameNoExtension}",
+            "--config",
+            "jest.config.js"
+          ],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen",
+          "disableOptimisticBPs": true,
+          "windows": {
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+          }
+        }
+      ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,6 +729,13 @@
       "integrity": "sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true
+    },
     "acorn": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
@@ -812,6 +819,24 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true,
+      "optional": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -1554,6 +1579,13 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "optional": true
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1628,6 +1660,13 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "optional": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1688,6 +1727,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true,
+      "optional": true
     },
     "conventional-changelog": {
       "version": "3.1.15",
@@ -2126,6 +2172,13 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "optional": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2188,6 +2241,13 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "optional": true
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -2196,6 +2256,13 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true,
+      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2837,6 +2904,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2849,7 +2926,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2891,6 +2969,64 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3396,6 +3532,13 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "optional": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3478,6 +3621,16 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -4863,6 +5016,27 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -4943,6 +5117,30 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+      "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -4980,6 +5178,36 @@
         "which": "^1.3.0"
       }
     },
+    "node-pre-gyp": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      }
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5001,6 +5229,35 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true,
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -5008,6 +5265,19 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -5176,6 +5446,17 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "2.0.0",
@@ -5471,6 +5752,35 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "react-is": {
       "version": "16.10.2",
@@ -6448,6 +6758,22 @@
         }
       }
     },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6887,6 +7213,39 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6980,6 +7339,13 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "optional": true
     },
     "yargs": {
       "version": "13.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5458,11 +5458,6 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-cancelable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
-    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -7323,9 +7318,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.3.tgz",
-      "integrity": "sha512-+1KyOB2JTv4kQQlZnEiDxSpEaIJnqslMa/479sc1KU3NMRP0caIV3p55Sr27GFS1EXQvnJ+n84bnWx77qplDWg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.8.0.tgz",
+      "integrity": "sha512-xHSYQtCHLkcrFRxa5lK4Lp1rnKt00a80jcKFMQiMBuE+6MvTYv7twwqYpzjsJoKFjGZB3GGEpZAuY1dmlPTh/g==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
   ],
   "files": [
     "dist/"
-  ],
-  "dependencies": {
-    "p-cancelable": "^2.0.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.1.3",
     "snapshot-diff": "^0.6.1",
-    "xstate": "^4.7.3"
+    "xstate": "^4.8.0"
   },
   "peerDependencies": {
-    "xstate": "^4.7.2"
+    "xstate": "^4.7.8"
   },
   "scripts": {
     "build": "rollup --config",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Build a tree of components based on statechart values",
   "author": "Pat Cavit <npm@patcavit.com>",
   "license": "MIT",
-  "module": "dist/treebuilder.mjs",
-  "main": "dist/treebuilder.js",
+  "module": "dist/component-tree.mjs",
+  "main": "dist/component-tree.js",
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.7.5",
     "@tivac/eslint-config": "^2.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,9 +4,9 @@ const { terser } = require("rollup-plugin-terser");
 
 const pkg = require("./package.json");
 
-const banner = `/*! ${pkg.name}@${pkg.version} !*/`;
+const banner = `/*! ${pkg.name}@${pkg.version} !*/\n`;
 
-const input = "./src/treebuilder.js";
+const input = "./src/component-tree.js";
 
 // ESM & CJS builds
 module.exports = {
@@ -41,7 +41,20 @@ module.exports = {
         format    : "es",
         sourcemap : true,
         plugins   : [
-            terser(),
+            terser({
+                mangle : {
+                    // Keep classnames intact for more usable stack traces
+                    keep_classnames : true,
+
+                    // Mangle properties
+                    properties : {
+                        // Except teardown because that's part of the public API
+                        reserved : [
+                            "teardown",
+                        ],
+                    },
+                },
+            }),
         ],
         banner,
     }],

--- a/src/treebuilder.js
+++ b/src/treebuilder.js
@@ -4,8 +4,8 @@ const loadComponent = async ({ item, load, context, event }) => {
     if(Array.isArray(result)) {
         const [ component, props ] = result;
 
-        item.component = component;
-        item.props = props;
+        item.component = await component;
+        item.props = await props;
     } else {
         item.component = result;
     }
@@ -30,7 +30,7 @@ class ComponentTree {
         // identifier!
         this.id = interpreter.id;
 
-        // Count # of times tree has been walked for cache viability
+        // Count # of times tree has been walked, used by cache & for walk cancellation
         this._counter = 0;
 
         // Caching for results of previous walks
@@ -45,7 +45,7 @@ class ComponentTree {
         // invoked id -> child machine
         this._children = new Map();
 
-        // Result of the walk is also available albeit quietly
+        // Expose walk result as a property
         this._tree = false;
 
         // Get goin

--- a/src/treebuilder.js
+++ b/src/treebuilder.js
@@ -240,13 +240,14 @@ class ComponentTree {
     
     // Callback for statechart transitions to sync up child machine states
     _state(data) {
+        const { changed, children } = data;
+
         // Need to specifically check for false because this value is undefined
         // when a machine first boots up
-        if(data.changed === false) {
+        if(changed === false) {
             return false;
         }
 
-        const { children } = data;
         const { _children } = this;
         
         // Clear out any old children that are no longer being tracked

--- a/src/treebuilder.js
+++ b/src/treebuilder.js
@@ -2,10 +2,10 @@ const loadComponent = async ({ item, load, context, event }) => {
     const result = await load(context, event);
 
     if(Array.isArray(result)) {
-        const [ component, props ] = result;
+        const [ component, props ] = await Promise.all(result);
 
-        item.component = await component;
-        item.props = await props;
+        item.component = component;
+        item.props = props;
     } else {
         item.component = result;
     }
@@ -16,8 +16,6 @@ const loadChild = async ({ child, root }) => {
     
     const children = await _tree;
 
-    // Will attach to the state itself if it has a component,
-    // otherwise will attach to the parent
     root.children.push(...children);
 };
 
@@ -220,7 +218,6 @@ class ComponentTree {
 
     // Kicks off tree walks & handles overlapping walk behaviors
     async _run(data) {
-        // Cancel any previous walks, we're the captain now
         const run = ++this._counter;
         
         this._tree = this._walk(data);
@@ -230,7 +227,7 @@ class ComponentTree {
             [ ...this._children.values() ].map(({ _tree }) => _tree),
         ]);
 
-        // New run started since this finished, abort
+        // New run started since this finished, abort instead of notifying
         if(run !== this._counter) {
             return;
         }

--- a/src/treebuilder.js
+++ b/src/treebuilder.js
@@ -95,7 +95,7 @@ class ComponentTree {
     }
 
     // Walk a machine via BFS, collecting meta information to build a tree
-    // eslint-disable-next-line max-statements
+    // eslint-disable-next-line max-statements, complexity
     async _walkRaw({ value, context, event }, onCancel) {
         const { _paths, _invocables, _children } = this;
 
@@ -131,7 +131,7 @@ class ComponentTree {
             // Using let since it can be reassigned if we add a new child
             let pointer = parent;
 
-            if(_paths.has(path) && !item) {
+            if(_paths.has(path)) {
                 const details = _paths.get(path);
                 const { component, props, load } = details;
 
@@ -155,10 +155,6 @@ class ComponentTree {
                 }
 
                 parent.children.push(item);
-            }
-            
-            if(item) {
-                console.log(path, item, root);
                 pointer = item;
             }
 

--- a/src/treebuilder.js
+++ b/src/treebuilder.js
@@ -70,7 +70,7 @@ class ComponentTree {
         // xstate maps ids to state nodes, but the value object only
         // has paths, so need to create our own path-only map here
         for(const id in ids) {
-            const { path, meta = false, invoke = false } = ids[id];
+            const { path, meta = false, invoke } = ids[id];
 
             const key = path.join(".");
 
@@ -86,9 +86,8 @@ class ComponentTree {
                 });
             }
 
-            if(invoke) {
-                invoke.forEach(({ id : invokeid }) => _invocables.set(key, invokeid));
-            }
+            // .invoke is always an array
+            invoke.forEach(({ id : invokeid }) => _invocables.set(key, invokeid));
         }
     }
 
@@ -164,7 +163,7 @@ class ComponentTree {
                         event,
                     });
 
-                    // Mark this state loaded in the cache once its acutally done
+                    // Mark this state loaded in the cache once its actually done
                     loading.then(() => {
                         const saved = _cache.get(path);
 
@@ -211,10 +210,6 @@ class ComponentTree {
             queue.push(...Object.keys(values).map((child) =>
                 [ pointer, `${path}.${child}`, values[child] ]
             ));
-        }
-
-        if(_counter !== this._counter) {
-            return false;
         }
 
         // await all the load functions

--- a/tests/__snapshots__/invoked-load.test.js.snap
+++ b/tests/__snapshots__/invoked-load.test.js.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`xstate-component-tree invoked machines using .load should pass child machine context & events to load fns 1`] = `
+exports[`xstate-component-tree should not re-run load on parent/child machine transitions 1`] = `
+Array [
+  "child1",
+  "one",
+]
+`;
+
+exports[`xstate-component-tree should not re-run load on parent/child machine transitions 2`] = `
+Array [
+  "two",
+]
+`;
+
+exports[`xstate-component-tree should not re-run load on parent/child machine transitions 3`] = `
+Array [
+  "child2",
+]
+`;
+
+exports[`xstate-component-tree should pass child machine context & events to load fns 1`] = `
 Array [
   Object {
     "children": Array [
@@ -21,7 +40,7 @@ Array [
 ]
 `;
 
-exports[`xstate-component-tree invoked machines using .load should support async .load 1`] = `
+exports[`xstate-component-tree should support async .load 1`] = `
 Array [
   Object {
     "children": Array [
@@ -37,7 +56,7 @@ Array [
 ]
 `;
 
-exports[`xstate-component-tree invoked machines using .load should support returning a component and props 1`] = `
+exports[`xstate-component-tree should support returning a component and props 1`] = `
 Array [
   Object {
     "children": Array [
@@ -55,7 +74,7 @@ Array [
 ]
 `;
 
-exports[`xstate-component-tree invoked machines using .load should support sync .load 1`] = `
+exports[`xstate-component-tree should support sync .load 1`] = `
 Array [
   Object {
     "children": Array [

--- a/tests/__snapshots__/invoked-load.test.js.snap
+++ b/tests/__snapshots__/invoked-load.test.js.snap
@@ -40,11 +40,17 @@ Array [
 exports[`xstate-component-tree invoked machines using .load should support returning a component and props 1`] = `
 Array [
   Object {
-    "children": Array [],
-    "component": "child",
-    "props": Object {
-      "props": true,
-    },
+    "children": Array [
+      Object {
+        "children": Array [],
+        "component": "child",
+        "props": Object {
+          "props": true,
+        },
+      },
+    ],
+    "component": "one",
+    "props": false,
   },
 ]
 `;

--- a/tests/__snapshots__/invoked-load.test.js.snap
+++ b/tests/__snapshots__/invoked-load.test.js.snap
@@ -37,6 +37,18 @@ Array [
 ]
 `;
 
+exports[`xstate-component-tree invoked machines using .load should support returning a component and props 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "component": "child",
+    "props": Object {
+      "props": true,
+    },
+  },
+]
+`;
+
 exports[`xstate-component-tree invoked machines using .load should support sync .load 1`] = `
 Array [
   Object {

--- a/tests/__snapshots__/invoked.test.js.snap
+++ b/tests/__snapshots__/invoked.test.js.snap
@@ -102,19 +102,19 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -6,11 +6,11 @@
-          "component": "child1",
-          "props": false,
-        },
+@@ -1,11 +1,11 @@
+  Array [
+    Object {
+      "children": Array [
         Object {
           "children": Array [],
 -         "component": "oneone",
 +         "component": "onetwo",
           "props": false,
         },
-      ],
-      "component": "one",
-      "props": false,
+        Object {
+          "children": Array [],
+          "component": "child1",
 `;
 
 exports[`xstate-component-tree invoked child machines should remove data once the invoke is halted 1`] = `

--- a/tests/__snapshots__/invoked.test.js.snap
+++ b/tests/__snapshots__/invoked.test.js.snap
@@ -1,43 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`xstate-component-tree invoked child machines should be supported 1`] = `
-Array [
-  Object {
-    "children": Array [
-      Object {
-        "children": Array [],
-        "component": "child",
-        "props": false,
-      },
-    ],
-    "component": "one",
-    "props": false,
-  },
-]
-`;
-
-exports[`xstate-component-tree invoked child machines should be supported in a parallel state 1`] = `
-Array [
-  Object {
-    "children": Array [
-      Object {
-        "children": Array [],
-        "component": "child",
-        "props": false,
-      },
-    ],
-    "component": "one",
-    "props": false,
-  },
-  Object {
-    "children": Array [],
-    "component": "two",
-    "props": false,
-  },
-]
-`;
-
-exports[`xstate-component-tree invoked child machines should ignore non-statechart children (callback) 1`] = `
+exports[`xstate component tree should ignore non-statechart children (callback) 1`] = `
 Array [
   Object {
     "children": Array [],
@@ -47,7 +10,7 @@ Array [
 ]
 `;
 
-exports[`xstate-component-tree invoked child machines should ignore non-statechart children (promise) 1`] = `
+exports[`xstate component tree should ignore non-statechart children (promise) 1`] = `
 Array [
   Object {
     "children": Array [],
@@ -57,7 +20,7 @@ Array [
 ]
 `;
 
-exports[`xstate-component-tree invoked child machines should rebuild on child transitions 1`] = `
+exports[`xstate component tree should rebuild on child machine transitions 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -77,7 +40,7 @@ Snapshot Diff:
       "props": false,
 `;
 
-exports[`xstate-component-tree invoked child machines should rebuild on nested invoked machine transitions 1`] = `
+exports[`xstate component tree should rebuild on nested invoked machine transitions 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -97,7 +60,7 @@ Snapshot Diff:
           "props": false,
 `;
 
-exports[`xstate-component-tree invoked child machines should rebuild on parent transitions 1`] = `
+exports[`xstate component tree should rebuild on parent transitions 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -117,7 +80,7 @@ Snapshot Diff:
           "component": "child1",
 `;
 
-exports[`xstate-component-tree invoked child machines should remove data once the invoke is halted 1`] = `
+exports[`xstate component tree should remove data once the invoked child machine is halted 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -138,7 +101,44 @@ Snapshot Diff:
   ]
 `;
 
-exports[`xstate-component-tree invoked child machines should support nested invoked machines 1`] = `
+exports[`xstate component tree should support invoked child machines 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [],
+        "component": "child",
+        "props": false,
+      },
+    ],
+    "component": "one",
+    "props": false,
+  },
+]
+`;
+
+exports[`xstate component tree should support invoked child machines in a parallel state 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [],
+        "component": "child",
+        "props": false,
+      },
+    ],
+    "component": "one",
+    "props": false,
+  },
+  Object {
+    "children": Array [],
+    "component": "two",
+    "props": false,
+  },
+]
+`;
+
+exports[`xstate component tree should support nested invoked machines 1`] = `
 Array [
   Object {
     "children": Array [

--- a/tests/__snapshots__/load.test.js.snap
+++ b/tests/__snapshots__/load.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`xstate-component-tree should allow the caching to be disabled globally 1`] = `
+Array [
+  "one",
+  "oneone",
+]
+`;
+
+exports[`xstate-component-tree should allow the caching to be disabled globally 2`] = `
+Array [
+  "one",
+]
+`;
+
+exports[`xstate-component-tree should allow the caching to be disabled locally 1`] = `
+Array [
+  "one",
+  "oneone",
+]
+`;
+
+exports[`xstate-component-tree should allow the caching to be disabled locally 2`] = `
+Array [
+  "one",
+]
+`;
+
 exports[`xstate-component-tree should ignore stale trees if component loads hadn't completed 1`] = `
 Array [
   Object {
@@ -22,6 +48,24 @@ Array [
     },
     "props": false,
   },
+]
+`;
+
+exports[`xstate-component-tree should re-run load functions when transitioning back to a state 1`] = `
+Array [
+  "one",
+]
+`;
+
+exports[`xstate-component-tree should re-run load functions when transitioning back to a state 2`] = `
+Array [
+  "two",
+]
+`;
+
+exports[`xstate-component-tree should re-run load functions when transitioning back to a state 3`] = `
+Array [
+  "one",
 ]
 `;
 

--- a/tests/__snapshots__/load.test.js.snap
+++ b/tests/__snapshots__/load.test.js.snap
@@ -51,6 +51,18 @@ Array [
 ]
 `;
 
+exports[`xstate-component-tree should support returning a component and props 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "component": "one",
+    "props": Object {
+      "props": true,
+    },
+  },
+]
+`;
+
 exports[`xstate-component-tree should support sync .load methods 1`] = `
 Array [
   Object {

--- a/tests/__snapshots__/load.test.js.snap
+++ b/tests/__snapshots__/load.test.js.snap
@@ -35,6 +35,42 @@ Array [
 ]
 `;
 
+exports[`xstate-component-tree should support async .load methods that return: async component & sync props 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "component": "one",
+    "props": Object {
+      "props": true,
+    },
+  },
+]
+`;
+
+exports[`xstate-component-tree should support async .load methods that return: sync component & async props 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "component": "one",
+    "props": Object {
+      "props": true,
+    },
+  },
+]
+`;
+
+exports[`xstate-component-tree should support async .load methods that return: sync component & sync props 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "component": "one",
+    "props": Object {
+      "props": true,
+    },
+  },
+]
+`;
+
 exports[`xstate-component-tree should support nested async .load methods 1`] = `
 Array [
   Object {

--- a/tests/__snapshots__/props.test.js.snap
+++ b/tests/__snapshots__/props.test.js.snap
@@ -1,33 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`xstate-component-tree props should pass context & event to dynamic props functions 1`] = `
-Array [
-  Object {
-    "children": Array [],
-    "component": "one",
-    "props": Array [
-      "context",
-      Object {
-        "type": "xstate.init",
-      },
-    ],
-  },
-]
-`;
-
-exports[`xstate-component-tree props should support async dynamic props 1`] = `
-Array [
-  Object {
-    "children": Array [],
-    "component": "one",
-    "props": Object {
-      "booga": 2,
-      "fooga": 1,
-    },
-  },
-]
-`;
-
 exports[`xstate-component-tree props should support static props 1`] = `
 Array [
   Object {
@@ -41,19 +13,6 @@ Array [
         },
       },
     ],
-    "component": "one",
-    "props": Object {
-      "booga": 2,
-      "fooga": 1,
-    },
-  },
-]
-`;
-
-exports[`xstate-component-tree props should support sync dynamic props 1`] = `
-Array [
-  Object {
-    "children": Array [],
     "component": "one",
     "props": Object {
       "booga": 2,

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -6,6 +6,16 @@ const trees = require("./util/trees.js");
 const component = require("./util/component.js");
 
 describe("xstate-component-tree", () => {
+    let tree;
+
+    afterEach(() => {
+        if(tree && tree.builder) {
+            tree.builder.teardown();
+        }
+
+        tree = null;
+    });
+    
     it("should return a tree of components", async () => {
         const testMachine = createMachine({
             initial : "one",
@@ -31,7 +41,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
 
         expect(await tree()).toMatchSnapshot();
     });
@@ -57,7 +67,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
 
         expect(await tree()).toMatchSnapshot();
     });
@@ -89,7 +99,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
 
         expect(await tree()).toMatchSnapshot();
     });
@@ -123,7 +133,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
 
         expect(await tree()).toMatchSnapshot();
     });
@@ -159,7 +169,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
 
         expect(await tree()).toMatchSnapshot();
     });
@@ -189,7 +199,7 @@ describe("xstate-component-tree", () => {
 
         const service = interpret(testMachine);
 
-        const tree = trees(service);
+        tree = trees(service);
         
         const before = await tree();
         
@@ -218,7 +228,7 @@ describe("xstate-component-tree", () => {
 
         service.onEvent(eventCounter);
 
-        const tree = trees(service);
+        tree = trees(service);
         
         await tree();
 
@@ -255,7 +265,7 @@ describe("xstate-component-tree", () => {
 
         const callback = jest.fn();
         
-        const tree = trees(service, callback);
+        tree = trees(service, callback);
         
         await tree();
         

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -87,6 +87,47 @@ describe("xstate-component-tree", () => {
             expect(await tree()).toMatchSnapshot();
         });
 
+        it("should support returning a component and props", async () => {
+            const childMachine = createMachine({
+                initial : "child",
+
+                states : {
+                    child : {
+                        meta : {
+                            load : () => [ component("child"), { props : true }],
+                        },
+                    },
+                },
+            });
+
+            const testMachine = createMachine({
+                initial : "one",
+
+                states : {
+                    one : {
+                        invoke : {
+                            id  : "child",
+                            src : childMachine,
+                        },
+
+                        meta : {
+                            component : component("one"),
+                        },
+                    },
+                },
+            });
+
+            const service = interpret(testMachine);
+
+            const tree = trees(service);
+            
+            // Root Built
+            await tree();
+            
+            // Child Built
+            expect(await tree()).toMatchSnapshot();
+        });
+
         it("should pass child machine context & events to load fns", async () => {
             const childMachine = createMachine({
                 initial : "child",

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -6,157 +6,260 @@ const component = require("./util/component.js");
 const loadAsync = require("./util/async-loader.js");
 
 describe("xstate-component-tree", () => {
-    describe("invoked machines using .load", () => {
-        it("should support sync .load", async () => {
-            const childMachine = createMachine({
-                initial : "child",
+    let tree;
 
-                states : {
-                    child : {
-                        meta : {
-                            load : () => component("child"),
-                        },
+    afterEach(() => {
+        if(tree && tree.builder) {
+            tree.builder.teardown();
+        }
+
+        tree = null;
+    });
+    
+    it("should support sync .load", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        load : () => component("child"),
                     },
                 },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
+            },
         });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
         
-        it("should support async .load", async () => {
-            const childMachine = createMachine({
-                initial : "child",
+        expect(await tree()).toMatchSnapshot();
+    });
+    
+    it("should support async .load", async () => {
+        const childMachine = createMachine({
+            initial : "child",
 
-                states : {
-                    child : {
-                        meta : {
-                            load : loadAsync(component("child")),
-                        },
+            states : {
+                child : {
+                    meta : {
+                        load : loadAsync(component("child")),
                     },
                 },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
+            },
         });
 
-        it("should support returning a component and props", async () => {
-            const childMachine = createMachine({
-                initial : "child",
+        const testMachine = createMachine({
+            initial : "one",
 
-                states : {
-                    child : {
-                        meta : {
-                            load : () => [ component("child"), { props : true }],
-                        },
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
                     },
                 },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
+            },
         });
 
-        it("should pass child machine context & events to load fns", async () => {
-            const childMachine = createMachine({
-                initial : "child",
+        const service = interpret(testMachine);
 
-                context : "child context",
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
 
-                states : {
-                    child : {
-                        meta : {
-                            load : (ctx, event) => ({ ctx, event }),
-                        },
+    it("should support returning a component and props", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        load : () => [ component("child"), { props : true }],
                     },
                 },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                context : "parent context",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
+            },
         });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it("should pass child machine context & events to load fns", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            context : "child context",
+
+            states : {
+                child : {
+                    meta : {
+                        load : (ctx, event) => ({ ctx, event }),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            context : "parent context",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it("should not re-run load on parent/child machine transitions", async () => {
+        let runs = [];
+        
+        const childMachine = createMachine({
+            initial : "child1",
+
+            states : {
+                child1 : {
+                    meta : {
+                        load : () => {
+                            runs.push("child1");
+
+                            return component("child1");
+                        },
+                    },
+
+                    on : {
+                        CHILD : "child2",
+                    },
+                },
+                
+                child2 : {
+                    meta : {
+                        load : () => {
+                            runs.push("child2");
+
+                            return component("child2");
+                        },
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            invoke : {
+                id  : "child",
+                src : childMachine,
+                
+                autoForward : true,
+            },
+
+            states : {
+                one : {
+                    meta : {
+                        load : () => {
+                            runs.push("one");
+
+                            return component("one");
+                        },
+                    },
+
+                    on : {
+                        PARENT : "two",
+                    },
+                },
+
+                two : {
+                    meta : {
+                        load : () => {
+                            runs.push("two");
+
+                            return component("two");
+                        },
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+
+        await tree();
+
+        expect(runs).toMatchSnapshot();
+
+        runs = [];
+
+        service.send("PARENT");
+        
+        await tree();
+
+        expect(runs).toMatchSnapshot();
+
+        runs = [];
+        
+        service.send("CHILD");
+        
+        await tree();
+
+        expect(runs).toMatchSnapshot();
     });
 });

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -41,8 +41,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            await tree();
-            
             expect(await tree()).toMatchSnapshot();
         });
         
@@ -80,10 +78,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            // Root Built
-            await tree();
-            
-            // Child Built
             expect(await tree()).toMatchSnapshot();
         });
 
@@ -121,10 +115,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            // Root Built
-            await tree();
-            
-            // Child Built
             expect(await tree()).toMatchSnapshot();
         });
 
@@ -165,8 +155,6 @@ describe("xstate-component-tree", () => {
             const service = interpret(testMachine);
 
             const tree = trees(service);
-            
-            await tree();
             
             expect(await tree()).toMatchSnapshot();
         });

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -51,7 +51,7 @@ describe("xstate-component-tree", () => {
                 states : {
                     child : {
                         meta : {
-                            load : loadAsync("child"),
+                            load : loadAsync(component("child")),
                         },
                     },
                 },

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -43,10 +43,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            // Root built
-            await tree();
-            
-            // Child built
             expect(await tree()).toMatchSnapshot();
         });
 
@@ -90,10 +86,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            // Root built
-            await tree();
-
-            // Child built
             expect(await tree()).toMatchSnapshot();
         });
 
@@ -122,7 +114,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
             
-            // Root built
             expect(await tree()).toMatchSnapshot();
         });
         
@@ -169,15 +160,10 @@ describe("xstate-component-tree", () => {
             const service = interpret(testMachine);
             const tree = trees(service);
             
-            // Root built
-            await tree();
-            
-            // Child built
             const before = await tree();
             
             service.send("NEXT");
             
-            // Root rebuilt
             const after = await tree();
 
             expect(before).toMatchDiffSnapshot(after);
@@ -229,15 +215,10 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
 
-            // Root built
-            await tree();
-
-            // Child built
             const before = await tree();
             
             service.send("NEXT");
             
-            // Child rebuilt
             const after = await tree();
 
             expect(before).toMatchDiffSnapshot(after);
@@ -297,15 +278,10 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
 
-            // Root built
-            await tree();
-
-            // Child built
             const before = await tree();
 
             service.send("NEXT");
 
-            // Root rebuilt
             const after = await tree();
 
             expect(before).toMatchDiffSnapshot(after);
@@ -366,13 +342,6 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
 
-            // Root built
-            await tree();
-
-            // Child built
-            await tree();
-
-            // Grandchild built
             expect(await tree()).toMatchSnapshot();
         });
 
@@ -441,18 +410,10 @@ describe("xstate-component-tree", () => {
 
             const tree = trees(service);
 
-            // Root built
-            await tree();
-
-            // Child built
-            await tree();
-            
-            // Grandchild built
             const before = await tree();
 
             service.send("NEXT");
             
-            // Grandchild rebuilt
             const after = await tree();
 
             expect(before).toMatchDiffSnapshot(after);

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -458,4 +458,7 @@ describe("xstate-component-tree", () => {
             expect(before).toMatchDiffSnapshot(after);
         });
     });
+
+    it.todo("should not re-run load on parent transitions");
+    it.todo("should not re-run load on child transitions");
 });

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -7,419 +7,424 @@ const { Machine : createMachine, interpret } = require("xstate");
 const trees = require("./util/trees.js");
 const component = require("./util/component.js");
 
-describe("xstate-component-tree", () => {
-    describe("invoked child machines", () => {
-        it("should be supported", async () => {
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        meta : {
-                            component : component("child"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child-machine",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
-        });
-
-        it("should be supported in a parallel state", async () => {
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        meta : {
-                            component : component("child"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                type : "parallel",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child-machine",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-
-                    two : {
-                        meta : {
-                            component : component("two"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
-        });
-
-        it.each([
-            [ "promise", () => new Promise(NOOP) ],
-            [ "callback", () => NOOP ],
-        ])("should ignore non-statechart children (%s)", async (name, src) => {
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id : "child",
-                            src,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-            
-            expect(await tree()).toMatchSnapshot();
-        });
-        
-        it("should remove data once the invoke is halted", async () => {
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        meta : {
-                            component : component("child"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-
-                        on : {
-                            NEXT : "two",
-                        },
-                    },
-
-                    two : {
-                        meta : {
-                            component : component("two"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-            const tree = trees(service);
-            
-            const before = await tree();
-            
-            service.send("NEXT");
-            
-            const after = await tree();
-
-            expect(before).toMatchDiffSnapshot(after);
-        });
-
-        it("should rebuild on child transitions", async () => {
-            const childMachine = createMachine({
-                initial : "child1",
-
-                states : {
-                    child1 : {
-                        meta : {
-                            component : component("child1"),
-                        },
-
-                        on : {
-                            NEXT : "child2",
-                        },
-                    },
-
-                    child2 : {
-                        meta : {
-                            component : component("child2"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                            
-                            autoForward : true,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-
-            const before = await tree();
-            
-            service.send("NEXT");
-            
-            const after = await tree();
-
-            expect(before).toMatchDiffSnapshot(after);
-        });
-
-        it("should rebuild on parent transitions", async () => {
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        meta : {
-                            component : component("child1"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-
-                        initial : "oneone",
-
-                        states : {
-                            oneone : {
-                                meta : {
-                                    component : component("oneone"),
-                                },
-
-                                on : {
-                                    NEXT : "onetwo",
-                                },
-                            },
-
-                            onetwo : {
-                                meta : {
-                                    component : component("onetwo"),
-                                },
-                            },
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-
-            const before = await tree();
-
-            service.send("NEXT");
-
-            const after = await tree();
-
-            expect(before).toMatchDiffSnapshot(after);
-        });
-
-        it("should support nested invoked machines", async () => {
-            const grandchildMachine = createMachine({
-                initial : "grandchild",
-
-                states : {
-                    grandchild : {
-                        meta : {
-                            component : component("grandchild"),
-                        },
-                    },
-                },
-            });
-
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        invoke : {
-                            id  : "grandchild-machine",
-                            src : grandchildMachine,
-
-                            autoForward : true,
-                        },
-
-                        meta : {
-                            component : component("child"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child-machine",
-                            src : childMachine,
-                            
-                            autoForward : true,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-
-            expect(await tree()).toMatchSnapshot();
-        });
-
-        it("should rebuild on nested invoked machine transitions", async () => {
-            const grandchildMachine = createMachine({
-                initial : "grandchild1",
-
-                states : {
-                    grandchild1 : {
-                        meta : {
-                            component : component("grandchild1"),
-                        },
-
-                        on : {
-                            NEXT : "grandchild2",
-                        },
-                    },
-
-                    grandchild2 : {
-                        meta : {
-                            component : component("grandchild2"),
-                        },
-                    },
-                },
-            });
-
-            const childMachine = createMachine({
-                initial : "child",
-
-                states : {
-                    child : {
-                        invoke : {
-                            id  : "grandchild",
-                            src : grandchildMachine,
-
-                            autoForward : true,
-                        },
-
-                        meta : {
-                            component : component("child"),
-                        },
-                    },
-                },
-            });
-
-            const testMachine = createMachine({
-                initial : "one",
-
-                states : {
-                    one : {
-                        invoke : {
-                            id  : "child",
-                            src : childMachine,
-                            
-                            autoForward : true,
-                        },
-
-                        meta : {
-                            component : component("one"),
-                        },
-                    },
-                },
-            });
-
-            const service = interpret(testMachine);
-
-            const tree = trees(service);
-
-            const before = await tree();
-
-            service.send("NEXT");
-            
-            const after = await tree();
-
-            expect(before).toMatchDiffSnapshot(after);
-        });
+describe("xstate component tree", () => {
+    let tree;
+
+    afterEach(() => {
+        if(tree && tree.builder) {
+            tree.builder.teardown();
+        }
+
+        tree = null;
     });
 
-    it.todo("should not re-run load on parent transitions");
-    it.todo("should not re-run load on child transitions");
+    it("should support invoked child machines", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child-machine",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it("should support invoked child machines in a parallel state", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            type : "parallel",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child-machine",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+
+                two : {
+                    meta : {
+                        component : component("two"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it.each([
+        [ "promise", () => new Promise(NOOP) ],
+        [ "callback", () => NOOP ],
+    ])("should ignore non-statechart children (%s)", async (name, src) => {
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id : "child",
+                        src,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+        
+        expect(await tree()).toMatchSnapshot();
+    });
+    
+    it("should remove data once the invoked child machine is halted", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+
+                    on : {
+                        NEXT : "two",
+                    },
+                },
+
+                two : {
+                    meta : {
+                        component : component("two"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+        tree = trees(service);
+        
+        const before = await tree();
+        
+        service.send("NEXT");
+        
+        const after = await tree();
+
+        expect(before).toMatchDiffSnapshot(after);
+    });
+
+    it("should rebuild on child machine transitions", async () => {
+        const childMachine = createMachine({
+            initial : "child1",
+
+            states : {
+                child1 : {
+                    meta : {
+                        component : component("child1"),
+                    },
+
+                    on : {
+                        NEXT : "child2",
+                    },
+                },
+
+                child2 : {
+                    meta : {
+                        component : component("child2"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                        
+                        autoForward : true,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+
+        const before = await tree();
+        
+        service.send("NEXT");
+        
+        const after = await tree();
+
+        expect(before).toMatchDiffSnapshot(after);
+    });
+
+    it("should rebuild on parent transitions", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child1"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+
+                    initial : "oneone",
+
+                    states : {
+                        oneone : {
+                            meta : {
+                                component : component("oneone"),
+                            },
+
+                            on : {
+                                NEXT : "onetwo",
+                            },
+                        },
+
+                        onetwo : {
+                            meta : {
+                                component : component("onetwo"),
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+
+        const before = await tree();
+
+        service.send("NEXT");
+
+        const after = await tree();
+
+        expect(before).toMatchDiffSnapshot(after);
+    });
+
+    it("should support nested invoked machines", async () => {
+        const grandchildMachine = createMachine({
+            initial : "grandchild",
+
+            states : {
+                grandchild : {
+                    meta : {
+                        component : component("grandchild"),
+                    },
+                },
+            },
+        });
+
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    invoke : {
+                        id  : "grandchild-machine",
+                        src : grandchildMachine,
+
+                        autoForward : true,
+                    },
+
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child-machine",
+                        src : childMachine,
+                        
+                        autoForward : true,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it("should rebuild on nested invoked machine transitions", async () => {
+        const grandchildMachine = createMachine({
+            initial : "grandchild1",
+
+            states : {
+                grandchild1 : {
+                    meta : {
+                        component : component("grandchild1"),
+                    },
+
+                    on : {
+                        NEXT : "grandchild2",
+                    },
+                },
+
+                grandchild2 : {
+                    meta : {
+                        component : component("grandchild2"),
+                    },
+                },
+            },
+        });
+
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    invoke : {
+                        id  : "grandchild",
+                        src : grandchildMachine,
+
+                        autoForward : true,
+                    },
+
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child",
+                        src : childMachine,
+                        
+                        autoForward : true,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        tree = trees(service);
+
+        const before = await tree();
+
+        service.send("NEXT");
+        
+        const after = await tree();
+
+        expect(before).toMatchDiffSnapshot(after);
+    });
 });

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -46,6 +46,26 @@ describe("xstate-component-tree", () => {
 
         expect(await tree()).toMatchSnapshot();
     });
+
+    it("should support returning a component and props", async () => {
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    meta : {
+                        load : () => [ component("one"), { props : true }],
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        const tree = trees(service);
+
+        expect(await tree()).toMatchSnapshot();
+    });
     
     it("should support async .load methods", async () => {
         const testMachine = createMachine({

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -198,4 +198,53 @@ describe("xstate-component-tree", () => {
 
         expect(runs).toEqual(1);
     });
+    
+    // Skipped because, well, it doesn't support this ATM
+    it.skip("should re-run load when a state is entered from an external self-transition", async () => {
+        let runs = 0;
+        
+        const testMachine = createMachine({
+            initial : "one",
+            context : "context",
+
+            states : {
+                one : {
+                    initial : "child1",
+
+                    meta : {
+                        load : () => {
+                            ++runs;
+
+                            return component("one");
+                        },
+                    },
+
+                    states : {
+                        child1 : {
+                            on : {
+                                NEXT : {
+                                    target   : "child1",
+                                    internal : false,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        const tree = trees(service);
+
+        await tree();
+
+        expect(runs).toEqual(1);
+        
+        service.send("NEXT");
+        
+        await tree();
+
+        expect(runs).toEqual(2);
+    });
 });

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -74,7 +74,31 @@ describe("xstate-component-tree", () => {
             states : {
                 one : {
                     meta : {
-                        load : loadAsync("one"),
+                        load : loadAsync(component("one")),
+                    },
+                },
+            },
+        });
+
+        const service = interpret(testMachine);
+
+        const tree = trees(service);
+
+        expect(await tree()).toMatchSnapshot();
+    });
+
+    it.each([
+        [ "sync component & sync props", loadAsync([ component("one"), { props : true }]) ],
+        [ "async component & sync props", loadAsync([ loadAsync(component("one"))(), { props : true }]) ],
+        [ "sync component & async props", loadAsync([ component("one"), loadAsync({ props : true })() ]) ],
+    ])("should support async .load methods that return: %s", async (name, load) => {
+        const testMachine = createMachine({
+            initial : "one",
+
+            states : {
+                one : {
+                    meta : {
+                        load,
                     },
                 },
             },
@@ -94,7 +118,7 @@ describe("xstate-component-tree", () => {
             states : {
                 one : {
                     meta : {
-                        load : loadAsync("one"),
+                        load : loadAsync(component("one")),
                     },
 
                     initial : "two",
@@ -102,7 +126,7 @@ describe("xstate-component-tree", () => {
                     states : {
                         two : {
                             meta : {
-                                load : loadAsync("two", 16),
+                                load : loadAsync(component("two"), 16),
                             },
                         },
                     },

--- a/tests/props.test.js
+++ b/tests/props.test.js
@@ -6,6 +6,16 @@ const trees = require("./util/trees.js");
 const component = require("./util/component.js");
 
 describe("xstate-component-tree", () => {
+    let tree;
+
+    afterEach(() => {
+        if(tree && tree.builder) {
+            tree.builder.teardown();
+        }
+
+        tree = null;
+    });
+    
     describe("props", () => {
         it("should support static props", async () => {
             const testMachine = createMachine({
@@ -40,7 +50,7 @@ describe("xstate-component-tree", () => {
     
             const service = interpret(testMachine);
     
-            const tree = trees(service);
+            tree = trees(service);
     
             expect(await tree()).toMatchSnapshot();
         });

--- a/tests/props.test.js
+++ b/tests/props.test.js
@@ -1,9 +1,9 @@
 "use strict";
 
 const { Machine : createMachine, interpret } = require("xstate");
+
 const trees = require("./util/trees.js");
 const component = require("./util/component.js");
-const asyncLoad = require("./util/async-loader.js");
 
 describe("xstate-component-tree", () => {
     describe("props", () => {
@@ -33,76 +33,6 @@ describe("xstate-component-tree", () => {
                                     },
                                 },
                             },
-                        },
-                    },
-                },
-            });
-    
-            const service = interpret(testMachine);
-    
-            const tree = trees(service);
-    
-            expect(await tree()).toMatchSnapshot();
-        });
-        
-        it("should support sync dynamic props", async () => {
-            const testMachine = createMachine({
-                initial : "one",
-    
-                states : {
-                    one : {
-                        meta : {
-                            component : component("one"),
-                            props     : () => ({
-                                fooga : 1,
-                                booga : 2,
-                            }),
-                        },
-                    },
-                },
-            });
-    
-            const service = interpret(testMachine);
-    
-            const tree = trees(service);
-    
-            expect(await tree()).toMatchSnapshot();
-        });
-
-        it("should support async dynamic props", async () => {
-            const testMachine = createMachine({
-                initial : "one",
-    
-                states : {
-                    one : {
-                        meta : {
-                            component : component("one"),
-                            props     : asyncLoad({
-                                fooga : 1,
-                                booga : 2,
-                            }),
-                        },
-                    },
-                },
-            });
-    
-            const service = interpret(testMachine);
-    
-            const tree = trees(service);
-    
-            expect(await tree()).toMatchSnapshot();
-        });
-        
-        it("should pass context & event to dynamic props functions", async () => {
-            const testMachine = createMachine({
-                initial : "one",
-                context : "context",
-    
-                states : {
-                    one : {
-                        meta : {
-                            component : component("one"),
-                            props     : (...args) => args,
                         },
                     },
                 },

--- a/tests/util/async-loader.js
+++ b/tests/util/async-loader.js
@@ -1,10 +1,8 @@
 "use strict";
 
-const component = require("./component.js");
-
-const load = (name, delay = 0) =>
+const load = (result, delay = 0) =>
     () => new Promise((resolve) =>
-        setTimeout(() => resolve(component(name)), delay)
+        setTimeout(() => resolve(result), delay)
     );
 
 module.exports = load;

--- a/tests/util/trees.js
+++ b/tests/util/trees.js
@@ -3,12 +3,9 @@
 const ComponentTree = require("../../src/treebuilder.js");
 const deferred = require("./deferred.js");
 
-// eslint-disable-next-line no-empty-function
-const noop = () => {};
-
 // Watch for trees to be built, and provide an easy way
 // to await each value
-const trees = (service, fn = noop) => {
+const trees = (service, fn = false, options) => {
     const responses = [];
     let idx = 0;
     let p;
@@ -41,10 +38,12 @@ const trees = (service, fn = noop) => {
     out.builder = new ComponentTree(service, (tree) => {
         responses.push(tree);
 
-        fn(tree);
+        if(fn) {
+            fn(tree);
+        }
 
         respond();
-    });
+    }, options);
 
     service.start();
 

--- a/tests/util/trees.js
+++ b/tests/util/trees.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const ComponentTree = require("../../src/treebuilder.js");
+const ComponentTree = require("../../src/component-tree.js");
 const deferred = require("./deferred.js");
 
 // Watch for trees to be built, and provide an easy way


### PR DESCRIPTION
- Caching of `load` responses to reduce extra work. Doesn't support external transitions to the same node, but that should be rare.
- Updated `load()` support so it can take either a `component` or `[ component, props ]` as a return and the overall `load()` as well as either `component` or `props` will be `await`ed.
- Only 1 callback per tree change, no matter if it was the deepest child or the root machine.
- Removed `Object.entries()` usage throughout
- Added 3rd arg to `ComponentTree(interpreter, callback, { caching : true|false })` to globally disable caching (default is enabled)
- Any `meta` object can set `cache : false` to disable caching for that particular state.
- Fleshed out `.teardown()` further
- Smaller output bundles by enabling property renaming
