### PR TITLE
feat: add path to return objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ new ComponentTree(service, (tree) => {
 });
 ```
 
-The second argument to the function will be called every time the machine transitions. It will pass the callback a new object representing all the views defined on currently active states, all correctly nested to match the structure of the statechart.
+The second argument to the function will be called every time the machine transitions. It will pass the callback a new object representing all the views defined on currently active states, all correctly nested to match the structure of the statechart. Each element in the response will also contain a `path` value corresponding to the the specific state the object represents.
 
 ```js
 new ComponentTree(service, (tree) => {
@@ -82,6 +82,7 @@ new ComponentTree(service, (tree) => {
      * tree will be something like this
      * 
      * [{
+     *     path : "one",
      *     component: MyComponent,
      *     children: [],
      *     props: false,
@@ -90,9 +91,11 @@ new ComponentTree(service, (tree) => {
      * or if there are nested components
      * 
      * [{
+     *     path : "one",
      *     component: MyComponent,
      *     props: false
      *     children : [{
+     *         path : "one.two",
      *         component : ChildComponent,
      *         props: {
      *             one : 1
@@ -157,8 +160,8 @@ The `load` function will be passed the `context` and `event` params from xstate.
 Once you have the tree of components, how you assembled that into your view layer is entirely up to you! Here's a brief [svelte](svelte.dev) example.
 
 ```html
-{#each components as { component, props, children }}
-    <svelte:component this={component} {children} {...props}>
+{#each components as { path, component, props, children } (path)}
+    <svelte:component this={component} {...props} {children} />
 {/each}
 
 <script>

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -41,7 +41,7 @@ class ComponentTree {
         this._paths = new Map();
 
         // path -> invoked id
-        this._invocables = new Map();
+        this._invokables = new Map();
 
         // invoked id -> child machine
         this._children = new Map();
@@ -59,7 +59,7 @@ class ComponentTree {
 
     teardown() {
         this._paths.clear();
-        this._invocables.clear();
+        this._invokables.clear();
         this._children.clear();
         this._cache.clear();
         
@@ -73,7 +73,7 @@ class ComponentTree {
     // Walk the machine and build up maps of paths to meta info as
     // well as prepping any load functions for usage later
     _prep() {
-        const { _paths, _invocables, _interpreter, _caching } = this;
+        const { _paths, _invokables, _interpreter, _caching } = this;
         const { idMap : ids } = _interpreter.machine;
 
         // xstate maps ids to state nodes, but the value object only
@@ -94,7 +94,7 @@ class ComponentTree {
             }
 
             // .invoke is always an array
-            invoke.forEach(({ id : invokeid }) => _invocables.set(key, invokeid));
+            invoke.forEach(({ id : invokeid }) => _invokables.set(key, invokeid));
         }
     }
 
@@ -113,8 +113,9 @@ class ComponentTree {
     // eslint-disable-next-line max-statements, complexity
     async _walk() {
         const {
+            id,
            _paths,
-           _invocables,
+           _invokables,
            _children,
            _cache,
            _counter,
@@ -125,7 +126,7 @@ class ComponentTree {
         const root = {
             __proto__ : null,
             
-            id       : this.id,
+            id,
             children : [],
         };
 
@@ -169,6 +170,8 @@ class ComponentTree {
                 const item = {
                     __proto__ : null,
 
+                    path,
+                    
                     component : cached ? cached.item.component : component,
                     props     : cached ? cached.item.props : props,
                     children  : [],
@@ -213,12 +216,12 @@ class ComponentTree {
                 pointer = item;
             }
 
-            if(_invocables.has(path)) {
-                const id = _invocables.get(path);
+            if(_invokables.has(path)) {
+                const invokable = _invokables.get(path);
 
-                if(_children.has(id)) {
+                if(_children.has(invokable)) {
                     loads.push(loadChild({
-                        child : _children.get(id),
+                        child : _children.get(invokable),
                         root  : pointer,
                     }));
                 }

--- a/tests/__snapshots__/basic.test.js.snap
+++ b/tests/__snapshots__/basic.test.js.snap
@@ -5,15 +5,16 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -2,6 +2,11 @@
-    Object {
+@@ -3,6 +3,12 @@
       "children": Array [],
       "component": "one",
+      "path": "one",
       "props": false,
     },
 +   Object {
 +     "children": Array [],
 +     "component": "b.two",
++     "path": "b.two",
 +     "props": false,
 +   },
   ]
@@ -24,15 +25,16 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -2,6 +2,11 @@
-    Object {
+@@ -3,6 +3,12 @@
       "children": Array [],
       "component": "one",
+      "path": "one",
       "props": false,
     },
 +   Object {
 +     "children": Array [],
 +     "component": "b.two",
++     "path": "b.two",
 +     "props": false,
 +   },
   ]
@@ -47,7 +49,9 @@ Snapshot Diff:
     Object {
       "children": Array [],
 -     "component": "one",
+-     "path": "one",
 +     "component": "two",
++     "path": "two",
       "props": false,
     },
   ]
@@ -60,10 +64,12 @@ Array [
       Object {
         "children": Array [],
         "component": "two",
+        "path": "one.two",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -76,10 +82,12 @@ Array [
       Object {
         "children": Array [],
         "component": "two",
+        "path": "one.two",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -92,10 +100,12 @@ Array [
       Object {
         "children": Array [],
         "component": "three",
+        "path": "one.two.three",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -106,11 +116,13 @@ Array [
   Object {
     "children": Array [],
     "component": "two",
+    "path": "one.two",
     "props": false,
   },
   Object {
     "children": Array [],
     "component": "three",
+    "path": "one.three",
     "props": false,
   },
 ]
@@ -121,11 +133,13 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": false,
   },
   Object {
     "children": Array [],
     "component": "two",
+    "path": "two",
     "props": false,
   },
 ]

--- a/tests/__snapshots__/invoked-load.test.js.snap
+++ b/tests/__snapshots__/invoked-load.test.js.snap
@@ -31,10 +31,12 @@ Array [
             "type": "xstate.init",
           },
         },
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -47,10 +49,12 @@ Array [
       Object {
         "children": Array [],
         "component": "child",
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -63,12 +67,14 @@ Array [
       Object {
         "children": Array [],
         "component": "child",
+        "path": "child",
         "props": Object {
           "props": true,
         },
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -81,10 +87,12 @@ Array [
       Object {
         "children": Array [],
         "component": "child",
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]

--- a/tests/__snapshots__/invoked.test.js.snap
+++ b/tests/__snapshots__/invoked.test.js.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -15,6 +16,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -25,19 +27,21 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -1,11 +1,11 @@
+@@ -1,12 +1,12 @@
   Array [
     Object {
       "children": Array [
         Object {
           "children": Array [],
 -         "component": "child1",
+-         "path": "child1",
 +         "component": "child2",
++         "path": "child2",
           "props": false,
         },
       ],
       "component": "one",
-      "props": false,
+      "path": "one",
 `;
 
 exports[`xstate component tree should rebuild on nested invoked machine transitions 1`] = `
@@ -45,19 +49,21 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -3,11 +3,11 @@
+@@ -3,12 +3,12 @@
       "children": Array [
         Object {
           "children": Array [
             Object {
               "children": Array [],
 -             "component": "grandchild1",
+-             "path": "grandchild1",
 +             "component": "grandchild2",
++             "path": "grandchild2",
               "props": false,
             },
           ],
           "component": "child",
-          "props": false,
+          "path": "child",
 `;
 
 exports[`xstate component tree should rebuild on parent transitions 1`] = `
@@ -65,14 +71,16 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -1,11 +1,11 @@
+@@ -1,12 +1,12 @@
   Array [
     Object {
       "children": Array [
         Object {
           "children": Array [],
 -         "component": "oneone",
+-         "path": "one.oneone",
 +         "component": "onetwo",
++         "path": "one.onetwo",
           "props": false,
         },
         Object {
@@ -91,11 +99,14 @@ Snapshot Diff:
 -       Object {
       "children": Array [],
 -         "component": "child",
+-         "path": "child",
 -         "props": false,
 -       },
 -     ],
 -     "component": "one",
+-     "path": "one",
 +     "component": "two",
++     "path": "two",
       "props": false,
     },
   ]
@@ -108,10 +119,12 @@ Array [
       Object {
         "children": Array [],
         "component": "child",
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -124,15 +137,18 @@ Array [
       Object {
         "children": Array [],
         "component": "child",
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
   Object {
     "children": Array [],
     "component": "two",
+    "path": "two",
     "props": false,
   },
 ]
@@ -147,14 +163,17 @@ Array [
           Object {
             "children": Array [],
             "component": "grandchild",
+            "path": "grandchild",
             "props": false,
           },
         ],
         "component": "child",
+        "path": "child",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]

--- a/tests/__snapshots__/load.test.js.snap
+++ b/tests/__snapshots__/load.test.js.snap
@@ -31,6 +31,7 @@ Array [
   Object {
     "children": Array [],
     "component": "two",
+    "path": "two",
     "props": false,
   },
 ]
@@ -46,6 +47,7 @@ Array [
         "type": "xstate.init",
       },
     },
+    "path": "one",
     "props": false,
   },
 ]
@@ -74,6 +76,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -84,6 +87,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": Object {
       "props": true,
     },
@@ -96,6 +100,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": Object {
       "props": true,
     },
@@ -108,6 +113,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": Object {
       "props": true,
     },
@@ -122,10 +128,12 @@ Array [
       Object {
         "children": Array [],
         "component": "two",
+        "path": "one.two",
         "props": false,
       },
     ],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]
@@ -136,6 +144,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": Object {
       "props": true,
     },
@@ -148,6 +157,7 @@ Array [
   Object {
     "children": Array [],
     "component": "one",
+    "path": "one",
     "props": false,
   },
 ]

--- a/tests/__snapshots__/props.test.js.snap
+++ b/tests/__snapshots__/props.test.js.snap
@@ -7,6 +7,7 @@ Array [
       Object {
         "children": Array [],
         "component": "two",
+        "path": "one.two",
         "props": Object {
           "tooga": 2,
           "wooga": 1,
@@ -14,6 +15,7 @@ Array [
       },
     ],
     "component": "one",
+    "path": "one",
     "props": Object {
       "booga": 2,
       "fooga": 1,


### PR DESCRIPTION
For easier keying in view layer, because component isn't always a good key choice.

Also replaced all instances of "invocable" because it looks stupid and "invokable" is more-correct seeming.