### PR TITLE
fix: prevent zombie children running

### DIFF
--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -262,4 +262,8 @@ describe("xstate-component-tree", () => {
 
         expect(runs).toMatchSnapshot();
     });
+
+    // TODO: How can this happen? It does in real apps, but haven't been able to write a test
+    // for it yet 😬😬😬
+    it.todo("should avoid re-running disposed children they send another update");
 });


### PR DESCRIPTION
Was refactoring an app using x-s-t and found it getting into a state where `_run()` instances were stacking up and finishing later, even after the instance itself had been torn down. Now it should be much harder to get into that state, but I've been unable to create a test to actually verify so far.

- Added more efficient stopped-children cleanup, no more manual tracking required.
- Only build up a tree of components if the statechart has any components to draw.
- Don't wait for a promise resolution if there's no uncached modules found on the walk.