### PR TITLE
chore: update coverage action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
       run: npm test -- --ci --coverage
 
     - name: Upload Coverage
-      uses: codecov/codecov-action@v1.0.2
+      uses: codecov/codecov-action@v2
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == 16
       with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage/coverage-final.json
+        files: ./coverage/coverage-final.json


### PR DESCRIPTION
`token` shouldn't be necessary since this is a public repo, hopefully it makes things more reliable too!