### PR TITLE
feat: make second callback arg useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ import { component } from "xstate-component-tree/component";
 The `callback` functions receives two arguments, the first is your assembled tree of components & props. The second is an object with some useful information on it:
 
 - `.state`, the returned xstate `State` object for the root machine
-- `.matches()`, a bound version of the `.matches()` API documented below
-- `.hasTag()`, a bound version of the `.hasTag()` API documented below
-- `.broadcast()`, a bound version of the `.broadcast()` API documented below
+- `.matches()`, a bound version of the [`.matches()` API documented below](#matchesstatename)
+- `.hasTag()`, a bound version of the [`.hasTag()` API documented below](#hastagtag)
+- `.broadcast()`, a bound version of the [`.broadcast()` API documented below](#broadcasteventname--eventobject-payload)
 
 #### `options`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@tivac/eslint-config": "^2.4.0",
         "c8": "^7.11.0",
+        "chokidar-cli": "^3.0.0",
         "dedent": "^0.7.0",
         "eslint": "^8.11.0",
         "esm": "^3.2.25",
@@ -305,6 +306,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -332,6 +346,15 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -340,6 +363,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer-from": {
@@ -500,6 +535,209 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "chokidar": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cliui": {
@@ -1545,6 +1783,18 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1981,6 +2231,18 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -2028,6 +2290,15 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
@@ -2315,6 +2586,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -2325,6 +2602,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -2565,6 +2848,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/null-check": {
@@ -2886,6 +3178,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -2931,6 +3235,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -3034,6 +3344,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3458,6 +3774,18 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -3602,6 +3930,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -3989,6 +4323,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4013,6 +4357,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4021,6 +4371,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "buffer-from": {
@@ -4132,6 +4491,169 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "cliui": {
@@ -4940,6 +5462,15 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5276,6 +5807,15 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -5310,6 +5850,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-obj": {
@@ -5544,6 +6090,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -5554,6 +6106,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
     "lru-cache": {
@@ -5739,6 +6297,12 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "null-check": {
       "version": "1.0.0",
@@ -5977,6 +6541,15 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -6006,6 +6579,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -6083,6 +6662,12 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -6406,6 +6991,15 @@
         "readable-stream": "3"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -6518,6 +7112,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@tivac/eslint-config": "^2.4.0",
     "c8": "^7.11.0",
+    "chokidar-cli": "^3.0.0",
     "dedent": "^0.7.0",
     "eslint": "^8.11.0",
     "esm": "^3.2.25",
@@ -44,6 +45,7 @@
     "test": "uvu",
     "test:coverage": "c8 --check-coverage --100 --reporter=html --reporter=text uvu",
     "test:report": "c8 report --reporter=text-lcov > coverage/tests.lcov",
+    "test:watch": "chokidar \"**/*.js\" -c \"npm test\"",
     "prerelease": "npm run test && npm run build",
     "release": "standard-version",
     "postrelease": "git push --follow-tags"

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -66,7 +66,6 @@ class ComponentTree {
 
         this._addService({ path : this.id, service });
         
-        
         // Caching for results of previous walks
         this._cache = new Map();
 
@@ -81,6 +80,12 @@ class ComponentTree {
 
         // eslint-disable-next-line no-console
         this._log = verbose ? console.log : noop;
+
+        this._boundApis = {
+            matches   : this.matches.bind(this),
+            hasTag    : this.hasTag.bind(this),
+            broadcast : this.broadcast.bind(this),
+        };
 
         // Get goin
         this._watch(this.id);
@@ -252,7 +257,11 @@ class ComponentTree {
 
         _log(`[${path}][_run #${run}] returning data`);
 
-        return _options.callback(tree, { data : this._state });
+        return _options.callback(tree, {
+            __proto__ : null,
+            state     : service.state,
+            ...this._boundApis,
+        });
     }
 
     // Walk a machine via BFS, collecting meta information to build a tree
@@ -436,6 +445,7 @@ class ComponentTree {
         
         this._options = null;
         this._log = null;
+        this._boundApis = null;
     }
 
     /**

--- a/tests/api/broadcast.test.js
+++ b/tests/api/broadcast.test.js
@@ -56,13 +56,17 @@ describe("broadcast", (it) => {
     it("should send to child trees", async (context) => {
         const tree = context.tree = createTree(grandchild);
 
-        const { tree : before } = await tree();
+        const { tree : one } = await tree();
 
         tree.builder.broadcast("NEXT");
 
-        const { tree : after } = await waitForPath(tree, "grandchild.two");
+        const { tree : two, extra } = await waitForPath(tree, "grandchild.two");
 
-        diff(before, after, `
+        extra.broadcast("NEXT");
+
+        const { tree : three } = await waitForPath(tree, "grandchild.three");
+
+        diff(one, two, `
         [
             [Object: null prototype] {
         Actual:
@@ -91,6 +95,40 @@ describe("broadcast", (it) => {
         Expected:
         ++        path: "grandchild.two",
         ++        component: [Function: grandchild-two],
+                props: false,
+                children: []
+            }
+        ]`);
+
+        diff(two, three, `
+        [
+            [Object: null prototype] {
+        Actual:
+        --        path: "root.two",
+        --        component: [Function: two],
+        Expected:
+        ++        path: "root.three",
+        ++        component: [Function: three],
+                props: false,
+                children: []
+            },
+            [Object: null prototype] {
+        Actual:
+        --        path: "child.two",
+        --        component: [Function: child-two],
+        Expected:
+        ++        path: "child.three",
+        ++        component: [Function: child-three],
+                props: false,
+                children: []
+            },
+            [Object: null prototype] {
+        Actual:
+        --        path: "grandchild.two",
+        --        component: [Function: grandchild-two],
+        Expected:
+        ++        path: "grandchild.three",
+        ++        component: [Function: grandchild-three],
                 props: false,
                 children: []
             }

--- a/tests/api/broadcast.test.js
+++ b/tests/api/broadcast.test.js
@@ -8,17 +8,23 @@ import grandchild from "./specimens/grandchild.js";
 
 describe("broadcast", (it) => {
     it.after.each(treeTeardown);
-    
+
     it("should send to the root tree", async (context) => {
         const tree = context.tree = createTree(single);
 
-        const before = await tree();
+        const { tree : one } = await tree();
         
+        // API on instance
         tree.builder.broadcast("NEXT");
 
-        const after = await waitForPath(tree, "two");
+        const { tree : two, extra } = await waitForPath(tree, "two");
 
-        diff(before, after, `
+        // API from extra
+        extra.broadcast("NEXT");
+
+        const { tree : three } = await waitForPath(tree, "three");
+
+        diff(one, two, `
         [
             [Object: null prototype] {
         Actual:
@@ -31,16 +37,30 @@ describe("broadcast", (it) => {
                 children: []
             }
         ]`);
+
+        diff(two, three, `
+        [
+            [Object: null prototype] {
+        Actual:
+        --        path: "two",
+        --        component: [Function: two],
+        Expected:
+        ++        path: "three",
+        ++        component: [Function: three],
+                props: false,
+                children: []
+            }
+        ]`);
     });
 
     it("should send to child trees", async (context) => {
         const tree = context.tree = createTree(grandchild);
 
-        const before = await tree();
+        const { tree : before } = await tree();
 
         tree.builder.broadcast("NEXT");
 
-        const after = await waitForPath(tree, "grandchild.two");
+        const { tree : after } = await waitForPath(tree, "grandchild.two");
 
         diff(before, after, `
         [

--- a/tests/api/hastag.test.js
+++ b/tests/api/hastag.test.js
@@ -13,15 +13,20 @@ describe("hasTag", (it) => {
     it("should check the root tree", async (context) => {
         const tree = context.tree = createTree(single);
 
+        const { extra } = await tree();
+
         assert.equal(tree.builder.hasTag("one"), true);
+        assert.equal(extra.hasTag("one"), true);
     });
 
     it("should check child trees", async (context) => {
         const tree = context.tree = createTree(child);
 
-        await tree();
+        const { extra } = await tree();
 
         assert.equal(tree.builder.hasTag("one"), true);
         assert.equal(tree.builder.hasTag("child-one"), true);
+        assert.equal(extra.hasTag("one"), true);
+        assert.equal(extra.hasTag("child-one"), true);
     });
 });

--- a/tests/api/matches.test.js
+++ b/tests/api/matches.test.js
@@ -13,18 +13,26 @@ describe("matches", (it) => {
     it("should check the root tree", async (context) => {
         const tree = context.tree = createTree(parallel);
 
+        const { extra } = await tree();
+
         assert.equal(tree.builder.matches("one"), true);
         assert.equal(tree.builder.matches("one.one_one"), true);
         assert.equal(tree.builder.matches("one.one_one.one_one_one"), true);
         assert.equal(tree.builder.matches("one.one_one.one_one_two"), true);
+        assert.equal(extra.matches("one"), true);
+        assert.equal(extra.matches("one.one_one"), true);
+        assert.equal(extra.matches("one.one_one.one_one_one"), true);
+        assert.equal(extra.matches("one.one_one.one_one_two"), true);
     });
 
     it("should check child trees", async (context) => {
         const tree = context.tree = createTree(child);
 
-        await tree();
+        const { extra } = await tree();
 
         assert.equal(tree.builder.matches("root.one"), true);
         assert.equal(tree.builder.matches("child.one"), true);
+        assert.equal(extra.matches("root.one"), true);
+        assert.equal(extra.matches("child.one"), true);
     });
 });

--- a/tests/api/specimens/grandchild.js
+++ b/tests/api/specimens/grandchild.js
@@ -25,6 +25,16 @@ const grandchild = createMachine({
                     meta : {
                         component : component("grandchild-two"),
                     },
+
+                    on : {
+                        NEXT : "three",
+                    },
+                },
+
+                three : {
+                    meta : {
+                        component : component("grandchild-three"),
+                    },
                 },
             },
         },
@@ -60,6 +70,16 @@ const child = createMachine({
                     meta : {
                         component : component("child-two"),
                     },
+
+                    on : {
+                        NEXT : "three",
+                    },
+                },
+
+                three : {
+                    meta : {
+                        component : component("child-three"),
+                    },
                 },
             },
         },
@@ -93,6 +113,16 @@ const root = createMachine({
                 two : {
                     meta : {
                         component : component("two"),
+                    },
+
+                    on : {
+                        NEXT : "three",
+                    },
+                },
+
+                three : {
+                    meta : {
+                        component : component("three"),
                     },
                 },
             },

--- a/tests/api/specimens/single.js
+++ b/tests/api/specimens/single.js
@@ -25,6 +25,18 @@ const single = createMachine({
             },
 
             tags : "two",
+
+            on : {
+                NEXT : "three",
+            },
+        },
+
+        three : {
+            meta : {
+                component : component("three"),
+            },
+
+            tags : "three",
         },
     },
 });

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -12,7 +12,76 @@ describe("basic functionality", (it) => {
     it.after.each(treeTeardown);
     
     it("should return a tree of components", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
+            initial : "one",
+
+            states : {
+                one : {
+                    meta : {
+                        component : component("one"),
+                    },
+
+                    initial : "two",
+
+                    states : {
+                        two : {
+                            meta : {
+                                component : component("two"),
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        snapshot(tree, `[
+            [Object: null prototype] {
+                path: "one",
+                component: [Function: one],
+                props: false,
+                children: [
+                    [Object: null prototype] {
+                        path: "one.two",
+                        component: [Function: two],
+                        props: false,
+                        children: []
+                    }
+                ]
+            }
+        ]`);
+    });
+
+    it("should return state info and APIs", async () => {
+        const { extra } = await getTree({
+            initial : "one",
+
+            states : {
+                one : {
+                    meta : {
+                        component : component("one"),
+                    },
+
+                    initial : "two",
+
+                    states : {
+                        two : {
+                            meta : {
+                                component : component("two"),
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        assert.type(extra.state, "object");
+        assert.type(extra.matches, "function");
+        assert.type(extra.hasTag, "function");
+        assert.type(extra.broadcast, "function");
+    });
+
+    it("should return a tree of components", async () => {
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -52,7 +121,7 @@ describe("basic functionality", (it) => {
     });
 
     it("should support props", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -106,7 +175,7 @@ describe("basic functionality", (it) => {
     });
 
     it("should support parallel states", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             type : "parallel",
 
             states : {
@@ -141,7 +210,7 @@ describe("basic functionality", (it) => {
     });
 
     it(`should support nested parallel states (stable: true)`, async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -182,7 +251,7 @@ describe("basic functionality", (it) => {
     });
     
     it(`should support nested parallel states (stable: false)`, async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -223,7 +292,7 @@ describe("basic functionality", (it) => {
     });
     
     it("should support arbitrary ids", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -267,7 +336,7 @@ describe("basic functionality", (it) => {
     });
 
     it("should support holes", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -337,11 +406,11 @@ describe("basic functionality", (it) => {
 
         context.tree = tree;
 
-        const before = await tree();
+        const { tree : before } = await tree();
         
         tree.service.send("NEXT");
 
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
             [Object: null prototype] {
@@ -420,11 +489,11 @@ describe("basic functionality", (it) => {
 
         context.tree = tree;
 
-        const before = await tree();
+        const { tree : before } = await tree();
         
         tree.service.send("NEXT");
 
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
             [Object: null prototype] {
@@ -476,11 +545,11 @@ describe("basic functionality", (it) => {
 
         context.tree = tree;
 
-        const before = await tree();
+        const { tree : before } = await tree();
         
         tree.service.send("NEXT");
 
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
             [Object: null prototype] {

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -66,7 +66,7 @@ describe("xstate-component-tree/helper", (it) => {
         ],
     ].forEach(([ name, meta, helpered ]) => {
         it(`should be the same: ${name}`, async () => {
-            const basic = await getTree({
+            const { tree : basic } = await getTree({
                 initial : "one",
     
                 states : {
@@ -76,7 +76,7 @@ describe("xstate-component-tree/helper", (it) => {
                 },
             });
     
-            const sugar = await getTree({
+            const { tree : sugar } = await getTree({
                 initial : "one",
     
                 states : {

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -24,7 +24,7 @@ describe(".load in invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -71,7 +71,7 @@ describe(".load in invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -118,7 +118,7 @@ describe(".load in invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -169,7 +169,7 @@ describe(".load in invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             context : "parent context",

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -25,7 +25,7 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -72,7 +72,7 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             type : "parallel",
 
             states : {
@@ -123,7 +123,7 @@ describe("invoked machines", (it) => {
         [ "callback", () => NOOP ],
     ].forEach(([ name, src ]) => {
         it(`should ignore non-statechart children (${name})`, async () => {
-            const tree = await getTree({
+            const { tree } = await getTree({
                 initial : "one",
 
                 states : {
@@ -191,11 +191,11 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const before = await tree();
+        const { tree : before } = await tree();
         
         tree.service.send("NEXT");
         
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
             [Object: null prototype] {
@@ -263,11 +263,11 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const before = await tree();
+        const { tree : before } = await tree();
         
         tree.service.send("NEXT");
         
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
                 [Object: null prototype] {
@@ -340,11 +340,11 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const before = await tree();
+        const { tree : before } = await tree();
 
         tree.service.send("NEXT");
 
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
                 [Object: null prototype] {
@@ -405,7 +405,7 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -509,11 +509,11 @@ describe("invoked machines", (it) => {
             },
         });
 
-        const before = await tree();
+        const { tree : before } = await tree();
 
         tree.service.send("NEXT");
         
-        const after = await tree();
+        const { tree : after } = await tree();
 
         diff(before, after, `[
                 [Object: null prototype] {

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -11,7 +11,7 @@ describe(".load support", (it) => {
     it.after.each(treeTeardown);
 
     it("should support sync .load methods", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -33,7 +33,7 @@ describe(".load support", (it) => {
     });
     
     it("should pass context and event params to .load methods", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             context : "context",
             states  : {
@@ -61,7 +61,7 @@ describe(".load support", (it) => {
     });
 
     it("should support returning a component and props", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -85,7 +85,7 @@ describe(".load support", (it) => {
     });
     
     it("should support async .load methods", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
 
             states : {
@@ -108,7 +108,7 @@ describe(".load support", (it) => {
     });
 
     it("should supprt async.load returning: sync component & sync props", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -132,7 +132,7 @@ describe(".load support", (it) => {
     });
     
     it("should supprt async.load returning: async component & sync props", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -156,7 +156,7 @@ describe(".load support", (it) => {
     });
     
     it("should supprt async.load returning: sync component & async props", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -180,7 +180,7 @@ describe(".load support", (it) => {
     });
 
     it("should support nested async .load methods", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             states  : {
                 one : {
@@ -246,7 +246,9 @@ describe(".load support", (it) => {
         // Purposefully not awaiting this, it'll never resolve!
         tree();
 
-        snapshot(await context.tree(), `[
+        const { tree : result } = await tree();
+
+        snapshot(result, `[
             [Object: null prototype] {
                 path: "two",
                 component: [Function: two],
@@ -479,7 +481,7 @@ describe(".load support", (it) => {
     });
 
     it("should ignore falsey components", async () => {
-        const tree = await getTree({
+        const { tree } = await getTree({
             initial : "one",
             
             states : {

--- a/tests/util/trees.js
+++ b/tests/util/trees.js
@@ -30,7 +30,9 @@ export const trees = (service, options = {}, fn = false) => {
             return;
         }
 
-        p.resolve(responses[idx++]);
+        const response = responses[idx++];
+
+        p.resolve({ tree : response[0], extra : response[1] });
     };
 
     const out = () => {
@@ -49,11 +51,11 @@ export const trees = (service, options = {}, fn = false) => {
     out.responses = responses;
     
     // Push new tree states onto array and respond if a request is waiting
-    out.builder = new ComponentTree(service, (tree) => {
-        responses.push(tree);
+    out.builder = new ComponentTree(service, (...other) => {
+        responses.push(other);
 
         if(fn) {
-            fn(tree);
+            fn(other);
         }
 
         respond();
@@ -94,7 +96,7 @@ export const waitForPath = async (tree, path) => {
         // eslint-disable-next-line no-await-in-loop
         val = await tree();
 
-        const searching = [ ...val ];
+        const searching = [ ...val.tree ];
 
         while(searching.length) {
             const item = searching.shift();


### PR DESCRIPTION
- Documenting new features
- Rearranging tests a bit to take advantage of new features
- 👇🏼👇🏼👇🏼

BREAKING CHANGE: previously the second arg to the callback function had a single `data` property on it representing the last `State` object seen by the top-level machine. Now it has `state` (same as `data` was previously), and some bound APIs for interacting with the statechart: `.hasTag()`, `.broadcast()`, and `.matches()`. These are the same APIs available on the `ComponentTree` instance but made available through the callback args for convenience.