### PR TITLE
chore: check APIs against no-component trees

### DIFF
--- a/tests/api/hastag.test.js
+++ b/tests/api/hastag.test.js
@@ -6,6 +6,7 @@ import { treeTeardown } from "../util/context.js";
 
 import single from "./specimens/single.js";
 import child from "./specimens/child.js";
+import noComponents from "./specimens/no-components.js";
 
 describe("hasTag", (it) => {
     it.after.each(treeTeardown);
@@ -13,10 +14,17 @@ describe("hasTag", (it) => {
     it("should check the root tree", async (context) => {
         const tree = context.tree = createTree(single);
 
-        const { extra } = await tree();
+        let { extra } = await tree();
 
-        assert.equal(tree.builder.hasTag("one"), true);
-        assert.equal(extra.hasTag("one"), true);
+        assert.ok(tree.builder.hasTag("one"));
+        assert.ok(extra.hasTag("one"));
+
+        tree.service.send("NEXT");
+
+        ({ extra } = await tree());
+
+        assert.ok(tree.builder.hasTag("two"));
+        assert.ok(extra.hasTag("two"));
     });
 
     it("should check child trees", async (context) => {
@@ -24,9 +32,25 @@ describe("hasTag", (it) => {
 
         const { extra } = await tree();
 
-        assert.equal(tree.builder.hasTag("one"), true);
-        assert.equal(tree.builder.hasTag("child-one"), true);
-        assert.equal(extra.hasTag("one"), true);
-        assert.equal(extra.hasTag("child-one"), true);
+        assert.ok(tree.builder.hasTag("one"));
+        assert.ok(tree.builder.hasTag("child-one"));
+        assert.ok(extra.hasTag("one"));
+        assert.ok(extra.hasTag("child-one"));
+    });
+
+    it("should work without components", async (context) => {
+        const tree = context.tree = createTree(noComponents);
+
+        let { extra } = await tree();
+
+        assert.ok(tree.builder.hasTag("one"));
+        assert.ok(extra.hasTag("one"));
+
+        tree.service.send("NEXT");
+
+        ({ extra } = await tree());
+
+        assert.ok(tree.builder.hasTag("two"));
+        assert.ok(extra.hasTag("two"));
     });
 });

--- a/tests/api/matches.test.js
+++ b/tests/api/matches.test.js
@@ -6,6 +6,7 @@ import { treeTeardown } from "../util/context.js";
 
 import parallel from "./specimens/parallel.js";
 import child from "./specimens/child.js";
+import noComponents from "./specimens/no-components.js";
 
 describe("matches", (it) => {
     it.after.each(treeTeardown);
@@ -15,14 +16,30 @@ describe("matches", (it) => {
 
         const { extra } = await tree();
 
-        assert.equal(tree.builder.matches("one"), true);
-        assert.equal(tree.builder.matches("one.one_one"), true);
-        assert.equal(tree.builder.matches("one.one_one.one_one_one"), true);
-        assert.equal(tree.builder.matches("one.one_one.one_one_two"), true);
-        assert.equal(extra.matches("one"), true);
-        assert.equal(extra.matches("one.one_one"), true);
-        assert.equal(extra.matches("one.one_one.one_one_one"), true);
-        assert.equal(extra.matches("one.one_one.one_one_two"), true);
+        assert.ok(tree.builder.matches("one"));
+        assert.ok(tree.builder.matches("one.one_one"));
+        assert.ok(tree.builder.matches("one.one_one.one_one_one"));
+        assert.ok(tree.builder.matches("one.one_one.one_one_two"));
+        assert.ok(extra.matches("one"));
+        assert.ok(extra.matches("one.one_one"));
+        assert.ok(extra.matches("one.one_one.one_one_one"));
+        assert.ok(extra.matches("one.one_one.one_one_two"));
+    });
+
+    it("should check trees without components", async (context) => {
+        const tree = context.tree = createTree(noComponents);
+
+        let { extra } = await tree();
+
+        assert.ok(tree.builder.matches("one"));
+        assert.ok(extra.matches("one"));
+
+        tree.service.send("NEXT");
+
+        ({ extra } = await tree());
+
+        assert.ok(tree.builder.matches("two"));
+        assert.ok(extra.matches("two"));
     });
 
     it("should check child trees", async (context) => {
@@ -30,9 +47,10 @@ describe("matches", (it) => {
 
         const { extra } = await tree();
 
-        assert.equal(tree.builder.matches("root.one"), true);
-        assert.equal(tree.builder.matches("child.one"), true);
-        assert.equal(extra.matches("root.one"), true);
-        assert.equal(extra.matches("child.one"), true);
+        assert.ok(tree.builder.matches("root.one"));
+        assert.ok(tree.builder.matches("child.one"));
+        assert.ok(extra.matches("root.one"));
+        assert.ok(extra.matches("child.one"));
     });
+    
 });

--- a/tests/api/matches.test.js
+++ b/tests/api/matches.test.js
@@ -52,5 +52,4 @@ describe("matches", (it) => {
         assert.ok(extra.matches("root.one"));
         assert.ok(extra.matches("child.one"));
     });
-    
 });

--- a/tests/api/specimens/no-components.js
+++ b/tests/api/specimens/no-components.js
@@ -1,0 +1,30 @@
+import { createMachine } from "xstate";
+
+const single = createMachine({
+    initial : "one",
+    id      : "single",
+
+    states : {
+        one : {
+            tags : "one",
+
+            on : {
+                NEXT : "two",
+            },
+        },
+
+        two : {
+            tags : "two",
+
+            on : {
+                NEXT : "three",
+            },
+        },
+
+        three : {
+            tags : "three",
+        },
+    },
+});
+
+export default single;


### PR DESCRIPTION
Because sometimes you want `.hasTag()` or `.broadcast()` but don't actually have a need for rendering trees of components.