### PR TITLE
fix: consistent subscriber values

### DIFF
--- a/.changeset/silver-drinks-notice.md
+++ b/.changeset/silver-drinks-notice.md
@@ -1,0 +1,9 @@
+---
+"xstate-component-tree": major
+---
+
+Always provide a valid initial value to subscribers
+
+Previously if you called the `.subscribe()` method on a `ComponentTree` instance before the statechart had been processed the return value would be `false`. This meant that subscribers would have to add checks to do anything against the returned value, since they couldn't depend on the `.matches`/`.hasTag`/`.broadcast` APIs existing.
+
+This change fixes that, and ensures that even if the statechart hasn't been walked yet the initial value stored has all the expected APIs, along with a reasonable value for the `tree` property of `[]`. There isn't a great fallback value for `.state` at this time though.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xstate-component-tree",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xstate-component-tree",
-      "version": "4.0.0",
+      "version": "4.2.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.5",

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -80,9 +80,6 @@ class ComponentTree {
         // Unsubscribe functions
         this._unsubscribes = new Set();
 
-        // Store off previous results in case new subscribers show up
-        this._result = false;
-
         // eslint-disable-next-line no-console
         this._log = verbose ? console.log : noop;
 
@@ -91,6 +88,16 @@ class ComponentTree {
             matches   : this.matches.bind(this),
             hasTag    : this.hasTag.bind(this),
             broadcast : this.broadcast.bind(this),
+        };
+
+        // Store off previous results in case new subscribers show up
+        this._result = {
+            __proto__ : null,
+
+            tree  : false,
+            state : false,
+            
+            ...this._boundApis,
         };
 
         // Add the main service to be tracked
@@ -170,6 +177,8 @@ class ComponentTree {
             this._unsubscribes.delete(unsubscribe);
             _services.delete(path);
         });
+
+        this._onState(path, interpreter.getSnapshot());
     }
 
     // Callback for statechart transitions to sync up child machine states

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -94,8 +94,8 @@ class ComponentTree {
         this._result = {
             __proto__ : null,
 
-            tree  : false,
-            state : false,
+            tree  : [],
+            state : service.getSnapshot(),
             
             ...this._boundApis,
         };
@@ -177,8 +177,6 @@ class ComponentTree {
             this._unsubscribes.delete(unsubscribe);
             _services.delete(path);
         });
-
-        this._onState(path, interpreter.getSnapshot());
     }
 
     // Callback for statechart transitions to sync up child machine states

--- a/tests/api/observable.test.js
+++ b/tests/api/observable.test.js
@@ -21,9 +21,15 @@ describe("observable", (it) => {
             out = result;
         });
 
-        // Should be false at first, before tree has run
+        // Initial value is basic but functional
         assert.is(calls, 1);
-        assert.is(out, false);
+        assert.type(out.state, "object");
+        assert.equal(out.tree, []);
+        assert.type(out.hasTag, "function");
+        assert.type(out.matches, "function");
+        assert.type(out.broadcast, "function");
+
+        assert.ok(out.hasTag("one"));
     });
 
     it("should call the callback whenever a run finishes", async (context) => {


### PR DESCRIPTION
Previously if you called the `.subscribe()` method on a `ComponentTree` instance before the statechart had been processed the return value would be `false`. This meant that subscribers would have to add checks to do anything against the returned value, since they couldn't depend on the `.matches`/`.hasTag`/`.broadcast` APIs existing.

This change fixes that, and ensures that even if the statechart hasn't been walked yet the initial value stored has all the expected APIs, along with a reasonable value for the `tree` property of `[]`. There isn't a great fallback value for `.state` at this time though.