### PR TITLE
fix: state methods need a state

### DIFF
--- a/.changeset/smooth-donkeys-attack.md
+++ b/.changeset/smooth-donkeys-attack.md
@@ -1,0 +1,5 @@
+---
+"xstate-component-tree": patch
+---
+
+Fix .hasTag & .matches before interpreter is running

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -116,7 +116,7 @@ class ComponentTree {
             run : 0,
 
             // Stored transition result, used to re-create the tree when a child transitions
-            state : false,
+            state : service.getSnapshot(),
 
             // Walk results
             tree : [],

--- a/tests/api/observable.test.js
+++ b/tests/api/observable.test.js
@@ -1,4 +1,7 @@
 import * as assert from "uvu/assert";
+import { interpret } from "xstate";
+
+import ComponentTree from "../../src/component-tree.js";
 
 import describe from "../util/describe.js";
 import { createTree } from "../util/trees.js";
@@ -9,13 +12,13 @@ import single from "./specimens/single.js";
 describe("observable", (it) => {
     it.after.each(treeTeardown);
 
-    it("should immediately call the callback", async (context) => {
-        const tree = context.tree = createTree(single);
+    it("should immediately call the callback", async () => {
+        const xct = new ComponentTree(interpret(single));
 
         let calls = 0;
         let out;
 
-        tree.builder.subscribe((result) => {
+        xct.subscribe((result) => {
             ++calls;
 
             out = result;
@@ -30,6 +33,8 @@ describe("observable", (it) => {
         assert.type(out.broadcast, "function");
 
         assert.ok(out.hasTag("one"));
+
+        xct.teardown();
     });
 
     it("should call the callback whenever a run finishes", async (context) => {
@@ -56,10 +61,11 @@ describe("observable", (it) => {
         assert.type(out.broadcast, "function");
 
         tree.send("NEXT");
-
+        
         await tree();
-
+        
         assert.is(calls, 3);
+        assert.ok(out.hasTag("two"));
     });
 
     it("should return an unsubscriber", async (context) => {


### PR DESCRIPTION
So using `.getSnapshot()` to get an initial state, even before the interpreter is necessarily started.