### PR TITLE
Root component support

### DIFF
--- a/.changeset/new-colts-yawn.md
+++ b/.changeset/new-colts-yawn.md
@@ -1,0 +1,25 @@
+---
+"xstate-component-tree": minor
+---
+
+Support for components at the root of machines
+
+```js
+createMachine({
+  initial : "foo",
+  
+  meta : {
+    component : RootComponent,
+  },
+
+  states : {
+    foo : {
+      meta : {
+        component: FooComponent
+      },
+    },
+  },
+});
+```
+
+Previously `RootComponent` would be ignored, now it will be the first component in the tree and `FooComponent` will be placed as a child of it.

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -51,7 +51,7 @@ describe("basic functionality", (it) => {
         ]`);
     });
 
-    it("should return a tree of components with a root component", async () => {
+    it("should support components at the machine root", async () => {
         const { tree } = await getTree({
             initial : "one",
 
@@ -63,16 +63,6 @@ describe("basic functionality", (it) => {
                 one : {
                     meta : {
                         component : component("one"),
-                    },
-
-                    initial : "two",
-
-                    states : {
-                        two : {
-                            meta : {
-                                component : component("two"),
-                            },
-                        },
                     },
                 },
             },
@@ -88,14 +78,7 @@ describe("basic functionality", (it) => {
                         path: "one",
                         component: [Function: one],
                         props: false,
-                        children: [
-                            [Object: null prototype] {
-                                path: "one.two",
-                                component: [Function: two],
-                                props: false,
-                                children: []
-                            }
-                        ]
+                        children: []
                     }
                 ]
             }

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -51,7 +51,7 @@ describe("basic functionality", (it) => {
         ]`);
     });
 
-    it.skip("should return a tree of components with a root component", async () => {
+    it("should return a tree of components with a root component", async () => {
         const { tree } = await getTree({
             initial : "one",
 

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -51,6 +51,57 @@ describe("basic functionality", (it) => {
         ]`);
     });
 
+    it.skip("should return a tree of components with a root component", async () => {
+        const { tree } = await getTree({
+            initial : "one",
+
+            meta : {
+                component : component("root"),
+            },
+
+            states : {
+                one : {
+                    meta : {
+                        component : component("one"),
+                    },
+
+                    initial : "two",
+
+                    states : {
+                        two : {
+                            meta : {
+                                component : component("two"),
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        snapshot(tree, `[
+            [Object: null prototype] {
+                path: false,
+                component: [Function: root],
+                props: false,
+                children: [
+                    [Object: null prototype] {
+                        path: "one",
+                        component: [Function: one],
+                        props: false,
+                        children: [
+                            [Object: null prototype] {
+                                path: "one.two",
+                                component: [Function: two],
+                                props: false,
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]`);
+    });
+
     it("should return state info and APIs", async () => {
         const { extra } = await getTree({
             initial : "one",

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -57,6 +57,64 @@ describe("invoked machines", (it) => {
         ]`);
     });
 
+    it("should support root components in invoked child machines", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            meta : {
+                component : component("root"),
+            },
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const { tree } = await getTree({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child-machine",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        snapshot(tree, `[
+            [Object: null prototype] {
+                path: "one",
+                component: [Function: one],
+                props: false,
+                children: [
+                    [Object: null prototype] {
+                        path: false,
+                        component: [Function: root],
+                        props: false,
+                        children: [
+                            [Object: null prototype] {
+                                path: "child",
+                                component: [Function: child],
+                                props: false,
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]`);
+    });
+
     it("should support invoked child machines in a parallel state", async () => {
         const childMachine = createMachine({
             initial : "child",


### PR DESCRIPTION
Lets you define machines like

```
createMachine({
    id : "foo",
    meta : {
        component : RootComponent,
    },

    initial : "foo",
    states : { ... }
});
```

And have `RootComponent` at the root of the component tree, as expected