### PR TITLE
fix: preserve `.meta` if it exists

### DIFF
--- a/.changeset/selfish-balloons-know.md
+++ b/.changeset/selfish-balloons-know.md
@@ -1,0 +1,19 @@
+---
+"xstate-component-tree": minor
+---
+
+Component helper preserves `.meta` fields
+
+Previous using the helper like this:
+
+```js
+helper(Component, {
+    meta : {
+        fooga : "wooga",
+    },
+});
+```
+
+would return an object with no `meta.fooga` property. Now those keys are properly preserved if they exist.
+
+`meta.load` will **still be overwritten** if it exists, because it is required for the helper to function. A warning if it exists may be introduced in a future release.

--- a/src/component-helper.js
+++ b/src/component-helper.js
@@ -34,7 +34,7 @@ export default (child, node = {}) => {
             props,
     ];
 
-    node.meta = meta;
+    node.meta = node.meta ? Object.assign(node.meta, meta) : meta;
 
     return node;
 };

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -7,6 +7,7 @@ import component from "./util/component.js";
 import { asyncValue, asyncLoad } from "./util/async.js";
 import { getTree } from "./util/trees.js";
 import { treeTeardown } from "./util/context.js";
+import { snapshot } from "./util/snapshot.js";
 
 describe("xstate-component-tree/helper", (it) => {
     it.after.each(treeTeardown);
@@ -86,5 +87,22 @@ describe("xstate-component-tree/helper", (it) => {
 
             assert.equal(basic, sugar);
         });
+    });
+
+    it("should maintain existing .meta properties if they exist", () => {
+        const node = helper(component("one"), {
+            meta : {
+                foo : "bar",
+                baz : true,
+            },
+        });
+
+        snapshot(node, `{
+            meta: {
+                foo: "bar",
+                baz: true,
+                load: [Function (anonymous)]
+            }
+        }`);
     });
 });


### PR DESCRIPTION
But don't do `Object.assign()` unless we have to for cost reasons.

Fixes #46 