### PR TITLE
fix: always walk machines once

### DIFF
--- a/.changeset/shy-experts-wink.md
+++ b/.changeset/shy-experts-wink.md
@@ -1,0 +1,9 @@
+---
+"xstate-component-tree": patch
+---
+
+Fix an issue where in specific situations child trees would not be built.
+
+If a child machine has an `invoke` that immediately triggers a no-op event, the `ComponentTree` instance wouldn't actually walk that child machine for components to render. This was due to an interesting interaction between the xstate `.changed` property and when `invoke`s within the statechart are run.
+
+Now whenever the `ComponentTree` sees a new machine it hasn't walked is running, it will walk it.

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -208,17 +208,19 @@ class ComponentTree {
     // Callback for statechart transitions to sync up child machine states
     _onState(path, state) {
         const { changed, children } = state;
+        const { _services, _log } = this;
         
+        const current = _services.get(path);
+
         // Need to specifically check for false because this value is undefined
-        // when a machine first boots up.
-        if(changed === false) {
+        // when a machine first boots up. Also check number of times we've built this machine
+        // and run anyways if we've never built it before
+        if(changed === false && current.run > 0) {
             return;
         }
         
-        const { _services, _log } = this;
-        
         // Save off the state
-        _services.get(path).state = state;
+        current.state = state;
 
         _log(`[${path}][_onState] checking children`);
 


### PR DESCRIPTION
Fix an issue where in specific situations child trees would not be built.

If a child machine has an `invoke` that immediately triggers a no-op event, the `ComponentTree` instance wouldn't actually walk that child machine for components to render. This was due to an interesting interaction between the xstate `.changed` property and when `invoke`s within the statechart are run.

Now whenever the `ComponentTree` sees a new machine it hasn't walked is running, it will walk it.