### PR TITLE
feat: Add machine to results

### DIFF
--- a/.changeset/clean-tigers-ring.md
+++ b/.changeset/clean-tigers-ring.md
@@ -1,0 +1,26 @@
+---
+"xstate-component-tree": minor
+---
+
+Add machine info to each result
+
+Otherwise root components of parallel sibling child machines can end up not being actually comparable.
+
+```diff
+[
+    [Object: null prototype] {
++       machine: "(machine).child-one",
+        path: false,
+        component: [Function: child],
+        props: false,
+        children: []
+    },
+    [Object: null prototype] {
++       machine: "(machine).child-two",
+        path: false,
+        component: [Function: child],
+        props: false,
+        children: []
+    }
+]
+```

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -37,13 +37,9 @@ const loadChild = async ({ tree, root }) => {
     root.children.push(...children);
 };
 
-const childPath = (...args) => {
-    const vals = [];
-
-    args.forEach((arg) => arg && vals.push(arg));
-
-    return vals.join(".");
-};
+const childPath = (...args) => args
+    .filter(Boolean)
+    .join(".");
 
 class ComponentTree {
     /**
@@ -391,6 +387,8 @@ class ComponentTree {
 
                 const item = {
                     __proto__ : null,
+
+                    machine : path,
 
                     // Purposefully *not* prefixing w/ path here, end-users don't care about it
                     path : node,

--- a/tests/api/broadcast.test.js
+++ b/tests/api/broadcast.test.js
@@ -27,6 +27,7 @@ describe("broadcast", (it) => {
         diff(one, two, `
         [
             [Object: null prototype] {
+                machine: "single",
         Actual:
         --        path: "one",
         --        component: [Function: one],
@@ -41,6 +42,7 @@ describe("broadcast", (it) => {
         diff(two, three, `
         [
             [Object: null prototype] {
+                machine: "single",
         Actual:
         --        path: "two",
         --        component: [Function: two],
@@ -69,6 +71,7 @@ describe("broadcast", (it) => {
         diff(one, two, `
         [
             [Object: null prototype] {
+                machine: "root",
         Actual:
         --        path: "root.one",
         --        component: [Function: one],
@@ -79,6 +82,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
+                machine: "root.child",
         Actual:
         --        path: "child.one",
         --        component: [Function: child-one],
@@ -89,6 +93,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
+                machine: "root.child.grandchild",
         Actual:
         --        path: "grandchild.one",
         --        component: [Function: grandchild-one],
@@ -103,6 +108,7 @@ describe("broadcast", (it) => {
         diff(two, three, `
         [
             [Object: null prototype] {
+                machine: "root",
         Actual:
         --        path: "root.two",
         --        component: [Function: two],
@@ -113,6 +119,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
+                machine: "root.child",
         Actual:
         --        path: "child.two",
         --        component: [Function: child-two],
@@ -123,6 +130,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
+                machine: "root.child.grandchild",
         Actual:
         --        path: "grandchild.two",
         --        component: [Function: grandchild-two],

--- a/tests/api/send.test.js
+++ b/tests/api/send.test.js
@@ -29,6 +29,7 @@ describe("send", (it) => {
         diff(one, two, `
         [
             [Object: null prototype] {
+                machine: "single",
         Actual:
         --        path: "one",
         --        component: [Function: one],
@@ -53,6 +54,7 @@ describe("send", (it) => {
         diff(one, two, `
         [
             [Object: null prototype] {
+                machine: "root",
         Actual:
         --        path: "root.one",
         --        component: [Function: one],
@@ -63,6 +65,7 @@ describe("send", (it) => {
                 children: []
             },
             [Object: null prototype] {
+                machine: "root.child",
                 path: "child.one",
                 component: [Function: child-one],
                 props: false,

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -36,11 +36,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [Function: two],
                         props: false,
@@ -82,11 +84,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [ [Function: one], [Function: two] ],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [ [Function: three], [Function: four] ],
                         props: false,
@@ -116,11 +120,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: false,
                 component: [Function: root],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one",
                         component: [Function: one],
                         props: false,
@@ -185,11 +191,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [Function: two],
                         props: false,
@@ -233,6 +241,7 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: {
@@ -241,6 +250,7 @@ describe("basic functionality", (it) => {
                 },
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [Function: two],
                         props: {
@@ -275,12 +285,14 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: []
             },
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "two",
                 component: [Function: two],
                 props: false,
@@ -316,12 +328,14 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one.three",
                 component: [Function: three],
                 props: false,
                 children: []
             },
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one.two",
                 component: [Function: two],
                 props: false,
@@ -357,12 +371,14 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one.two",
                 component: [Function: two],
                 props: false,
                 children: []
             },
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one.three",
                 component: [Function: three],
                 props: false,
@@ -400,11 +416,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [Function: two],
                         props: false,
@@ -446,11 +464,13 @@ describe("basic functionality", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two.three",
                         component: [Function: three],
                         props: false,
@@ -494,6 +514,7 @@ describe("basic functionality", (it) => {
 
         diff(before, after, `[
             [Object: null prototype] {
+                machine: "(machine)",
         Actual:
         --        path: "one",
         --        component: [Function: one],
@@ -577,6 +598,7 @@ describe("basic functionality", (it) => {
 
         diff(before, after, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
@@ -584,6 +606,7 @@ describe("basic functionality", (it) => {
         Expected:
         ++    },
         ++    [Object: null prototype] {
+        ++        machine: "(machine)",
         ++        path: "b.two",
         ++        component: [Function: b.two],
         ++        props: false,
@@ -633,6 +656,7 @@ describe("basic functionality", (it) => {
 
         diff(before, after, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
@@ -640,6 +664,7 @@ describe("basic functionality", (it) => {
         Expected:
         ++    },
         ++    [Object: null prototype] {
+        ++        machine: "(machine)",
         ++        path: "b.two",
         ++        component: [Function: b.two],
         ++        props: false,

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -42,11 +42,13 @@ describe(".load in invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -89,11 +91,13 @@ describe(".load in invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -136,11 +140,13 @@ describe(".load in invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: {
@@ -189,11 +195,13 @@ describe(".load in invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: {
                             ctx: "child context",

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -29,7 +29,7 @@ describe("invoked machines", (it) => {
             states : {
                 one : {
                     invoke : {
-                        id  : "child-machine",
+                        id  : "child",
                         src : childMachine,
                     },
 
@@ -42,11 +42,13 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -80,7 +82,7 @@ describe("invoked machines", (it) => {
             states : {
                 one : {
                     invoke : {
-                        id  : "child-machine",
+                        id  : "child",
                         src : childMachine,
                     },
 
@@ -93,16 +95,19 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: false,
                         component: [Function: root],
                         props: false,
                         children: [
                             [Object: null prototype] {
+                                machine: "(machine).child",
                                 path: "child",
                                 component: [Function: child],
                                 props: false,
@@ -134,7 +139,7 @@ describe("invoked machines", (it) => {
             states : {
                 one : {
                     invoke : {
-                        id  : "child-machine",
+                        id  : "child",
                         src : childMachine,
                     },
 
@@ -153,11 +158,13 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -166,6 +173,7 @@ describe("invoked machines", (it) => {
                 ]
             },
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "two",
                 component: [Function: two],
                 props: false,
@@ -198,6 +206,7 @@ describe("invoked machines", (it) => {
 
             snapshot(tree, `[
                 [Object: null prototype] {
+                    machine: "(machine)",
                     path: "one",
                     component: [Function: one],
                     props: false,
@@ -255,6 +264,7 @@ describe("invoked machines", (it) => {
 
         diff(before, after, `[
             [Object: null prototype] {
+                machine: "(machine)",
         Actual:
         --        path: "one",
         --        component: [Function: one],
@@ -265,6 +275,7 @@ describe("invoked machines", (it) => {
         Actual:
         --        children: [
         --            [Object: null prototype] {
+        --                machine: "(machine).child",
         --                path: "child",
         --                component: [Function: child],
         --                props: false,
@@ -330,6 +341,7 @@ describe("invoked machines", (it) => {
 
         diff(before, after, `[
             [Object: null prototype] {
+                machine: "(machine)",
         Actual:
         --        path: "one",
         --        component: [Function: one],
@@ -340,6 +352,7 @@ describe("invoked machines", (it) => {
         Actual:
         --        children: [
         --            [Object: null prototype] {
+        --                machine: "(machine).child",
         --                path: "child",
         --                component: [Function: child],
         --                props: false,
@@ -402,11 +415,13 @@ describe("invoked machines", (it) => {
 
         diff(before, after, `[
                 [Object: null prototype] {
+                    machine: "(machine)",
                     path: "one",
                     component: [Function: one],
                     props: false,
                     children: [
                         [Object: null prototype] {
+                            machine: "(machine).child",
             Actual:
             --                path: "child1",
             --                component: [Function: child1],
@@ -479,11 +494,13 @@ describe("invoked machines", (it) => {
 
         diff(before, after, `[
                 [Object: null prototype] {
+                    machine: "(machine)",
                     path: "one",
                     component: [Function: one],
                     props: false,
                     children: [
                         [Object: null prototype] {
+                            machine: "(machine)",
             Actual:
             --                path: "one.oneone",
             --                component: [Function: oneone],
@@ -494,6 +511,7 @@ describe("invoked machines", (it) => {
                             children: []
                         },
                         [Object: null prototype] {
+                            machine: "(machine).child",
                             path: "child",
                             component: [Function: child1],
                             props: false,
@@ -523,7 +541,7 @@ describe("invoked machines", (it) => {
             states : {
                 child : {
                     invoke : {
-                        id  : "grandchild-machine",
+                        id  : "grandchild",
                         src : grandchildMachine,
 
                         autoForward : true,
@@ -542,7 +560,7 @@ describe("invoked machines", (it) => {
             states : {
                 one : {
                     invoke : {
-                        id  : "child-machine",
+                        id  : "child",
                         src : childMachine,
                         
                         autoForward : true,
@@ -557,16 +575,19 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine).child",
                         path: "child",
                         component: [Function: child],
                         props: false,
                         children: [
                             [Object: null prototype] {
+                                machine: "(machine).child.grandchild",
                                 path: "grandchild",
                                 component: [Function: grandchild],
                                 props: false,
@@ -648,16 +669,19 @@ describe("invoked machines", (it) => {
 
         diff(before, after, `[
                 [Object: null prototype] {
+                    machine: "(machine)",
                     path: "one",
                     component: [Function: one],
                     props: false,
                     children: [
                         [Object: null prototype] {
+                            machine: "(machine).child",
                             path: "child",
                             component: [Function: child],
                             props: false,
                             children: [
                                 [Object: null prototype] {
+                                    machine: "(machine).child.grandchild",
             Actual:
             --                        path: "grandchild1",
             --                        component: [Function: grandchild1],
@@ -712,6 +736,7 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "parent.child",
                 path: "one",
                 component: [Function: child-one],
                 props: false,

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -181,6 +181,57 @@ describe("invoked machines", (it) => {
             }
         ]`);
     });
+    
+    it("should support invoked child machines in a parallel state with root components", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+            
+            meta : {
+                component : component("child"),
+            },
+
+            states : {
+                child : {},
+            },
+        });
+
+        const { tree } = await getTree({
+            type : "parallel",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "child-one",
+                        src : childMachine,
+                    },
+                },
+
+                two : {
+                    invoke : {
+                        id  : "child-two",
+                        src : childMachine,
+                    },
+                },
+            },
+        });
+
+        snapshot(tree, `[
+            [Object: null prototype] {
+                machine: "(machine).child-one",
+                path: false,
+                component: [Function: child],
+                props: false,
+                children: []
+            },
+            [Object: null prototype] {
+                machine: "(machine).child-two",
+                path: false,
+                component: [Function: child],
+                props: false,
+                children: []
+            }
+        ]`);
+    });
 
     [
         [ "promise", () => new Promise(NOOP) ],

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -24,6 +24,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
@@ -47,6 +48,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: {
                     ctx: "context",
@@ -74,6 +76,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: {
@@ -99,6 +102,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
@@ -121,6 +125,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: {
@@ -145,6 +150,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: {
@@ -169,6 +175,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: {
@@ -203,11 +210,13 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: [Function: one],
                 props: false,
                 children: [
                     [Object: null prototype] {
+                        machine: "(machine)",
                         path: "one.two",
                         component: [Function: two],
                         props: false,
@@ -250,6 +259,7 @@ describe(".load support", (it) => {
 
         snapshot(result, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "two",
                 component: [Function: two],
                 props: false,
@@ -495,6 +505,7 @@ describe(".load support", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
+                machine: "(machine)",
                 path: "one",
                 component: false,
                 props: false,


### PR DESCRIPTION
Otherwise root components of parallel sibling child machines can end up not being actually comparable.

```diff
[
    [Object: null prototype] {
+       machine: "(machine).child-one",
        path: false,
        component: [Function: child],
        props: false,
        children: []
    },
    [Object: null prototype] {
+       machine: "(machine).child-two",
        path: false,
        component: [Function: child],
        props: false,
        children: []
    }
]
```