### PR TITLE
Matching state and invoke names

### DIFF
--- a/.changeset/slow-planets-begin.md
+++ b/.changeset/slow-planets-begin.md
@@ -1,0 +1,20 @@
+---
+"xstate-component-tree": major
+---
+
+Matching state and invoke names would cause `xstate-component-tree` to fail to return child components in some cases because internally it named them the same thing and stomped all over itself.
+
+```
+states : {
+    foo : {
+        invoke : {
+            id : "foo",
+            // ...
+        },
+    },
+},
+```
+
+This should work now.
+
+**BREAKING CHANGE**: All `machine` values in the output that previously looked like `root.foo` will now look like `root.#foo`, in order to help differentiate the child machine `id` from the parent state path.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+    
         {
             "name": "uvu All",
             "type": "node",
@@ -15,6 +16,23 @@
             "args": [
                 "tests",
                 "\\.test\\.js$"
+            ],
+            "console": "integratedTerminal",
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/uvu/bin.js"
+            }
+        },
+        {
+            "name": "uvu Current",
+            "type": "node",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/node_modules/.bin/uvu",
+            "args": [
+                "tests",
+                "${fileBasename}"
             ],
             "console": "integratedTerminal",
             "windows": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xstate-component-tree",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xstate-component-tree",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",

--- a/tests/api/broadcast.test.js
+++ b/tests/api/broadcast.test.js
@@ -82,7 +82,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child",
+                machine: "root.#child",
         Actual:
         --        path: "child.one",
         --        component: [Function: child-one],
@@ -93,7 +93,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child.grandchild",
+                machine: "root.#child.#grandchild",
         Actual:
         --        path: "grandchild.one",
         --        component: [Function: grandchild-one],
@@ -119,7 +119,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child",
+                machine: "root.#child",
         Actual:
         --        path: "child.two",
         --        component: [Function: child-two],
@@ -130,7 +130,7 @@ describe("broadcast", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child.grandchild",
+                machine: "root.#child.#grandchild",
         Actual:
         --        path: "grandchild.two",
         --        component: [Function: grandchild-two],

--- a/tests/api/send.test.js
+++ b/tests/api/send.test.js
@@ -65,7 +65,7 @@ describe("send", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child",
+                machine: "root.#child",
                 path: "child.one",
                 component: [Function: child-one],
                 props: false,

--- a/tests/api/verbose.test.js
+++ b/tests/api/verbose.test.js
@@ -20,7 +20,7 @@ describe("verbose", (it) => {
         restoreAll();
 
         // Only check first & last for now
-        snapshot(log.calls[0], `[ "[root][_prep] prepping" ]`);
+        snapshot(log.calls[0], `[ "[root][_watch] prepping" ]`);
         snapshot(log.calls[log.calls.length - 1], `[ "[root][_run #2] returning data" ]`);
     });
 });

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -66,7 +66,7 @@ describe("basic functionality", (it) => {
                 children: []
             },
             [Object: null prototype] {
-                machine: "root.child",
+                machine: "root.#child",
                 path: "child.one",
                 component: [Function: child-one],
                 props: false,

--- a/tests/invoked-load.test.js
+++ b/tests/invoked-load.test.js
@@ -48,7 +48,7 @@ describe(".load in invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -97,7 +97,7 @@ describe(".load in invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -146,7 +146,7 @@ describe(".load in invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: {
@@ -201,7 +201,7 @@ describe(".load in invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: {
                             ctx: "child context",

--- a/tests/invoked.test.js
+++ b/tests/invoked.test.js
@@ -49,7 +49,56 @@ describe("invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
+                        path: "child",
+                        component: [Function: child],
+                        props: false,
+                        children: []
+                    }
+                ]
+            }
+        ]`);
+    });
+    
+    it("should support invoked child machines with state names", async () => {
+        const childMachine = createMachine({
+            initial : "child",
+
+            states : {
+                child : {
+                    meta : {
+                        component : component("child"),
+                    },
+                },
+            },
+        });
+
+        const { tree } = await getTree({
+            initial : "one",
+
+            states : {
+                one : {
+                    invoke : {
+                        id  : "one",
+                        src : childMachine,
+                    },
+
+                    meta : {
+                        component : component("one"),
+                    },
+                },
+            },
+        });
+
+        snapshot(tree, `[
+            [Object: null prototype] {
+                machine: "test",
+                path: "one",
+                component: [Function: one],
+                props: false,
+                children: [
+                    [Object: null prototype] {
+                        machine: "test.#one",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -94,7 +143,7 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
-                machine: "test.child",
+                machine: "test.#child",
                 path: "child",
                 component: [Function: child],
                 props: false,
@@ -146,13 +195,13 @@ describe("invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: false,
                         component: [Function: root],
                         props: false,
                         children: [
                             [Object: null prototype] {
-                                machine: "test.child",
+                                machine: "test.#child",
                                 path: "child",
                                 component: [Function: child],
                                 props: false,
@@ -209,7 +258,7 @@ describe("invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: false,
@@ -262,14 +311,14 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
-                machine: "test.child-one",
+                machine: "test.#child-one",
                 path: false,
                 component: [Function: child],
                 props: false,
                 children: []
             },
             [Object: null prototype] {
-                machine: "test.child-two",
+                machine: "test.#child-two",
                 path: false,
                 component: [Function: child],
                 props: false,
@@ -371,7 +420,7 @@ describe("invoked machines", (it) => {
         Actual:
         --        children: [
         --            [Object: null prototype] {
-        --                machine: "test.child",
+        --                machine: "test.#child",
         --                path: "child",
         --                component: [Function: child],
         --                props: false,
@@ -448,7 +497,7 @@ describe("invoked machines", (it) => {
         Actual:
         --        children: [
         --            [Object: null prototype] {
-        --                machine: "test.child",
+        --                machine: "test.#child",
         --                path: "child",
         --                component: [Function: child],
         --                props: false,
@@ -515,7 +564,7 @@ describe("invoked machines", (it) => {
                     props: false,
                     children: [
                         [Object: null prototype] {
-                            machine: "test.child",
+                            machine: "test.#child",
             Actual:
             --                path: "child1",
             --                component: [Function: child1],
@@ -605,7 +654,7 @@ describe("invoked machines", (it) => {
                             children: []
                         },
                         [Object: null prototype] {
-                            machine: "test.child",
+                            machine: "test.#child",
                             path: "child",
                             component: [Function: child1],
                             props: false,
@@ -671,13 +720,13 @@ describe("invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: false,
                         children: [
                             [Object: null prototype] {
-                                machine: "test.child.grandchild",
+                                machine: "test.#child.#grandchild",
                                 path: "grandchild",
                                 component: [Function: grandchild],
                                 props: false,
@@ -761,13 +810,13 @@ describe("invoked machines", (it) => {
                 props: false,
                 children: [
                     [Object: null prototype] {
-                        machine: "test.child",
+                        machine: "test.#child",
                         path: "child",
                         component: [Function: child],
                         props: false,
                         children: [
                             [Object: null prototype] {
-                                machine: "test.child.grandchild",
+                                machine: "test.#child.#grandchild",
         Actual:
         --                        path: "grandchild1",
         --                        component: [Function: grandchild1],
@@ -822,7 +871,7 @@ describe("invoked machines", (it) => {
 
         snapshot(tree, `[
             [Object: null prototype] {
-                machine: "parent.child",
+                machine: "parent.#child",
                 path: "one",
                 component: [Function: child-one],
                 props: false,


### PR DESCRIPTION
Previously something like this would fail to render some children

```
states : {
    foo : {
        invoke : {
            id : "foo",
            // ...
        },
    },
},
```

because `xstate-component-tree` conflated path names and invokable names. Added a [test showing this failing](https://github.com/tivac/xstate-component-tree/compare/state-and-invoke-names?expand=1#diff-098df89c720f14fa22860c13b7d3c3df0312635f9ad819fa19f08887beb1ed3bR63-L61) and then fixed the functionality inside `xstate-component-tree` by prefixing invoked IDs with `#` instead of leaving them plain.