### PR TITLE
fix: handle actors that immediately complete

### DIFF
--- a/.changeset/vast-beans-retire.md
+++ b/.changeset/vast-beans-retire.md
@@ -1,0 +1,5 @@
+---
+"xstate-component-tree": patch
+---
+
+fix: handle actors that immediately complete

--- a/src/component-tree.js
+++ b/src/component-tree.js
@@ -237,7 +237,7 @@ class ComponentTree {
             complete : () => {
                 _log(`[${path}][subscribe.complete] stopped, tearing down`);
 
-                unsubscribe();
+                unsubscribe?.();
 
                 this._unsubscribes.delete(unsubscribe);
                 _actors.delete(path);
@@ -562,7 +562,7 @@ class ComponentTree {
         this._destroyed = true;
 
         for(const unsub of this._unsubscribes) {
-            unsub();
+            unsub?.();
         }
         
         this._paths.clear();


### PR DESCRIPTION
Sometimes actors can complete synchronously, handle that by calling the `unsubscribe` conditionally.